### PR TITLE
Flipped respective return values for OCV image container width/height methods

### DIFF
--- a/doc/rel_notes/0.5.1.txt
+++ b/doc/rel_notes/0.5.1.txt
@@ -27,3 +27,8 @@ Documentation
    added algorithms and containers and sorted the lists.
 
   * Added missing algorithm on the OCV module Doxygen main page and sorted.
+
+OCV Module
+
+  * Flipped repective returns in width/height getter methods as they were
+    previously returning the incorrect values.

--- a/maptk/ocv/image_container.h
+++ b/maptk/ocv/image_container.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2013-2014 by Kitware, Inc.
+ * Copyright 2013-2015 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -77,10 +77,10 @@ public:
   virtual size_t size() const;
 
   /// The width of the image in pixels
-  virtual size_t width() const { return data_.rows; }
+  virtual size_t width() const { return data_.cols; }
 
   /// The height of the image in pixels
-  virtual size_t height() const { return data_.cols; }
+  virtual size_t height() const { return data_.rows; }
 
   /// The depth (or number of channels) of the image
   virtual size_t depth() const { return data_.channels(); }


### PR DESCRIPTION
Previously returning the opposite value from what they should have
returned.