### PR TITLE
Fix vxl camera test

### DIFF
--- a/doc/rel_notes/0.5.1.txt
+++ b/doc/rel_notes/0.5.1.txt
@@ -26,12 +26,12 @@ Documentation
  * Added missing documentation on the VXL module Doxygen main page for recently
    added algorithms and containers and sorted the lists.
 
-  * Added missing algorithm on the OCV module Doxygen main page and sorted.
+ * Added missing algorithm on the OCV module Doxygen main page and sorted.
 
 OCV Module
 
-  * Flipped repective returns in width/height getter methods as they were
-    previously returning the incorrect values.
+ * Flipped repective returns in width/height getter methods as they were
+   previously returning the incorrect values.
 
 VXL Module
 

--- a/doc/rel_notes/0.5.1.txt
+++ b/doc/rel_notes/0.5.1.txt
@@ -32,3 +32,10 @@ OCV Module
 
   * Flipped repective returns in width/height getter methods as they were
     previously returning the incorrect values.
+
+VXL Module
+
+ * Fixed a camera conversion test that was failing on some platforms.  Compare
+   the camera parameters directly instead of computing a 3x4 projection matrix
+   for each and comparing that.  Computing the matrix introduces additional
+   floating point precision error which should not be a part of this test.

--- a/tests/vxl/test_camera.cxx
+++ b/tests/vxl/test_camera.cxx
@@ -97,9 +97,21 @@ void test_convert_camera(T eps)
   vpgl_perspective_camera<T> vcam2;
   vxl::maptk_to_vpgl_camera(mcam, vcam2);
 
-  double err = (vcam.get_matrix() - vcam2.get_matrix()).frobenius_norm();
-  std::cout << "Camera matrix difference: "<<err<<std::endl;
-  TEST_NEAR("Camera converted vpgl-->maptk-->vpgl", err, 0.0, eps);
+
+  double err = ( vcam.get_calibration().get_matrix()
+               - vcam2.get_calibration().get_matrix() ).absolute_value_max();
+  std::cout << "Camera calibration matrix difference: "<<err<<std::endl;
+  TEST_NEAR("Camera converted vpgl-->maptk-->vpgl (K)", err, 0.0, eps);
+
+  err = ( vcam.get_rotation().as_quaternion()
+        - vcam2.get_rotation().as_quaternion() ).inf_norm();
+  std::cout << "Camera rotation difference: "<<err<<std::endl;
+  TEST_NEAR("Camera converted vpgl-->maptk-->vpgl (R)", err, 0.0, eps);
+
+  err = ( vcam.get_camera_center()
+        - vcam2.get_camera_center() ).length();
+  std::cout << "Camera center difference: "<<err<<std::endl;
+  TEST_NEAR("Camera converted vpgl-->maptk-->vpgl (t)", err, 0.0, eps);
 }
 
 


### PR DESCRIPTION
Fixed a camera conversion test that was failing on some platforms.  Compare the camera parameters directly instead of computing a 3x4 projection matrix for each and comparing that.  Computing the matrix introduces additional floating point precision error which should not be a part of this test.