### PR TITLE
Fix CMake warnings on release branch

### DIFF
--- a/cmake/maptk-flags.cmake
+++ b/cmake/maptk-flags.cmake
@@ -14,7 +14,7 @@ define_property(GLOBAL PROPERTY maptk_warnings
 function(maptk_check_compiler_flag flag)
   string(REPLACE "+" "plus" safeflag "${flag}")
   check_cxx_compiler_flag("${flag}" "has_compiler_flag-${safeflag}")
-  if ("has_compiler_flag-${safeflag}")
+  if (has_compiler_flag-${safeflag})
     set_property(GLOBAL APPEND PROPERTY maptk_warnings "${flag}")
   endif()
 endfunction ()

--- a/cmake/utils/maptk-utils-targets.cmake
+++ b/cmake/utils/maptk-utils-targets.cmake
@@ -133,6 +133,11 @@ function(maptk_add_library name)
   string(TOUPPER "${name}" upper_name)
   message(STATUS "Making library \"${name}\" with defined symbol \"MAKE_${upper_name}_LIB\"")
 
+  # Use RPaths on Mac OSX
+  if( APPLE )
+    set(_maptk_osx_rpath MACOSX_RPATH TRUE)
+  endif()
+
   add_library("${name}" ${ARGN})
   set_target_properties("${name}"
     PROPERTIES
@@ -142,6 +147,7 @@ function(maptk_add_library name)
       VERSION                  ${MAPTK_VERSION}
       SOVERSION                0
       DEFINE_SYMBOL            MAKE_${upper_name}_LIB
+      ${_maptk_osx_rpath}
     )
 
   add_dependencies("${name}"

--- a/doc/rel_notes/0.5.1.txt
+++ b/doc/rel_notes/0.5.1.txt
@@ -23,6 +23,10 @@ Tools
 Fixes since v0.5.0
 ------------------
 
+Build System
+
+ * Fixed some CMake configuration warnings.
+
 Documentation
 
  * Added missing algorithms on the MAP-Tk core mainpage and sorted existing


### PR DESCRIPTION
These changes were already addressed in master as part of the major overhaul.  This branch back-ports some minor changes from master to the release branch in order to clean up some CMake warnings on the previous release.

When merging release into master, changes from this branch will conflict.  The conflict resolution should be to reject these changes and keep master as it was.