### PR TITLE
Relaxed tolerances on some similarity estimation tests

### DIFF
--- a/tests/vxl/test_estimate_similarity.cxx
+++ b/tests/vxl/test_estimate_similarity.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2014 by Kitware, Inc.
+ * Copyright 2014-2015 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -138,7 +138,7 @@ IMPLEMENT_TEST(reprojection_100pts)
 
   TEST_NEAR("Crafted and estimated similarity transforms match",
             (matrix_4x4d(m_sim) - matrix_4x4d(e_sim)).frobenius_norm(),
-            0.0, 1e-14);
+            0.0, 1e-12);
 
   cerr << "Constructing crafted similarity transformation WITH ZERO TRANSLATION" << endl;
   m_sim = similarity_d(5.623,
@@ -161,7 +161,7 @@ IMPLEMENT_TEST(reprojection_100pts)
 
   TEST_NEAR("Crafted and estimated similarity transforms match",
             (matrix_4x4d(m_sim) - matrix_4x4d(e_sim)).frobenius_norm(),
-            0.0, 1e-13);
+            0.0, 1e-12);
 }
 
 


### PR DESCRIPTION
These tolerances were slightly too tight on a clang build on Ubuntu 12.04, which is used for Travis CI testing.