### PR TITLE
Re-enabled all ctest tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,4 @@ script:
           -DMAPTK_ENABLE_TESTING:BOOL=ON
           ../
   - make
-  # Several tests are known to fail due to VXL bugs in the Ubuntu package.
-  # Ignore these tests for now until there is a fixed VXL.
-  - ctest -E "vxl_estimate_essential_matrix-.*points|vxl_initialize_cameras_landmarks-.*points|vxl_initialize_cameras_landmarks-subset_init"
+  - ctest


### PR DESCRIPTION
Previously some tests were failing due to bugs in VXL.  An updated
VXL package in a PPA should resolve these issues.