### PR TITLE
Fix some minor stuff

### DIFF
--- a/CMake/maptk-depends-Eigen.cmake
+++ b/CMake/maptk-depends-Eigen.cmake
@@ -1,4 +1,4 @@
 # Required Eigen external dependency
 
 find_package(Eigen3 REQUIRED)
-include_directories(${EIGEN3_INCLUDE_DIR})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})

--- a/CMake/utils/maptk-utils-targets.cmake
+++ b/CMake/utils/maptk-utils-targets.cmake
@@ -181,8 +181,8 @@ function(maptk_add_library name)
   # Setting Properties
   set_target_properties("${name}"
     PROPERTIES
-      ARCHIVE_OUTPUT_DIRECTORY "${MAPTK_BINARY_DIR}/lib${library_subdir}"
-      LIBRARY_OUTPUT_DIRECTORY "${MAPTK_BINARY_DIR}/lib${library_subdir}"
+      ARCHIVE_OUTPUT_DIRECTORY "${MAPTK_BINARY_DIR}/lib${LIB_SUFFIX}${library_subdir}"
+      LIBRARY_OUTPUT_DIRECTORY "${MAPTK_BINARY_DIR}/lib${LIB_SUFFIX}${library_subdir}"
       RUNTIME_OUTPUT_DIRECTORY "${MAPTK_BINARY_DIR}/bin${library_subdir}"
       COMPILE_DEFINITIONS      "${new_compile_definitions}"
       ${_maptk_version_info}
@@ -193,8 +193,8 @@ function(maptk_add_library name)
     string(TOUPPER "${config}" upper_config)
     set_target_properties("${name}"
       PROPERTIES
-        "ARCHIVE_OUTPUT_DIRECTORY_${upper_config}" "${MAPTK_BINARY_DIR}/lib/${config}${library_subdir}"
-        "LIBRARY_OUTPUT_DIRECTORY_${upper_config}" "${MAPTK_BINARY_DIR}/lib/${config}${library_subdir}"
+        "ARCHIVE_OUTPUT_DIRECTORY_${upper_config}" "${MAPTK_BINARY_DIR}/lib${LIB_SUFFIX}/${config}${library_subdir}"
+        "LIBRARY_OUTPUT_DIRECTORY_${upper_config}" "${MAPTK_BINARY_DIR}/lib${LIB_SUFFIX}/${config}${library_subdir}"
         "RUNTIME_OUTPUT_DIRECTORY_${upper_config}" "${MAPTK_BINARY_DIR}/bin/${config}${library_subdir}"
       )
   endforeach()
@@ -213,8 +213,8 @@ function(maptk_add_library name)
   maptk_install(
     TARGETS             "${name}"
     ${exports}
-    ARCHIVE DESTINATION lib${MAPTK_LIB_SUFFIX}${library_subdir}
-    LIBRARY DESTINATION lib${MAPTK_LIB_SUFFIX}${library_subdir}
+    ARCHIVE DESTINATION lib${LIB_SUFFIX}${library_subdir}
+    LIBRARY DESTINATION lib${LIB_SUFFIX}${library_subdir}
     RUNTIME DESTINATION bin${library_subdir}
     COMPONENT           ${component}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ else()
   option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
 endif()
 
-set(LIB_SUFFIX "" CACHE STRING "String suffix appended to the library directory we install into")
+# default to MAPTK_LIB_SUFFIX for backwards compatibility
+if(DEFINED MAPTK_LIB_SUFFIX)
+  message(WARNING "MAPTK_LIB_SUFFIX is deprecated. Please use LIB_SUFFIX instead.")
+endif()
+set(LIB_SUFFIX "${MAPTK_LIB_SUFFIX}" CACHE STRING "String suffix appended to the library directory we install into")
 
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
   option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
 endif()
 
-set(MAPTK_LIB_SUFFIX "" CACHE STRING "String suffix appended to the library directory we install into")
+set(LIB_SUFFIX "" CACHE STRING "String suffix appended to the library directory we install into")
 
 
 ###
@@ -72,7 +72,7 @@ endif()
 ###
 # Top level installation
 #
-set(maptk_cmake_install_dir "lib${MAPTK_LIB_SUFFIX}/cmake/maptk")
+set(maptk_cmake_install_dir "lib${LIB_SUFFIX}/cmake/maptk")
 
 # Install rules for CMake utilities
 include(maptk-install-utils)
@@ -97,7 +97,7 @@ maptk_export_targets("${MAPTK_BINARY_DIR}/maptk-config-targets.cmake")
 
 # Configure install-tree CMake config file and export associated targets file
 set(MAPTK_CONFIG_INSTALL_FILE "${MAPTK_BINARY_DIR}/maptk-config-install.cmake")
-set(module_path "${CMAKE_INSTALL_PREFIX}/lib${MAPTK_LIB_SUFFIX}/cmake/maptk")
+set(module_path "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/cmake/maptk")
 maptk_configure_file(maptk-install-config
   "${MAPTK_SOURCE_DIR}/CMake/maptk-config-install.cmake.in"
   "${MAPTK_CONFIG_INSTALL_FILE}"

--- a/doc/rel_notes/1.0.0.txt
+++ b/doc/rel_notes/1.0.0.txt
@@ -32,7 +32,9 @@ Build System
  * Added Eigen3 include directory path to include directories exported by
    MAP-Tk.
 
- * Added support for LIB_SUFFIX.
+ * Added support for LIB_SUFFIX.  This supersedes MAPTK_LIB_SUFFIX; if the old
+   variable is set, it will be used as the default value for LIB_SUFFIX, but a
+   warning will be issued.
 
 MAP-Tk Library
 

--- a/doc/rel_notes/1.0.0.txt
+++ b/doc/rel_notes/1.0.0.txt
@@ -29,7 +29,10 @@ Build System
 
  * Simplified string logic for finding compiler flags file.
 
- * Added Eigen3 include directory path to include directories exported by MAP-Tk
+ * Added Eigen3 include directory path to include directories exported by
+   MAP-Tk.
+
+ * Added support for LIB_SUFFIX.
 
 MAP-Tk Library
 

--- a/maptk/CMakeLists.txt
+++ b/maptk/CMakeLists.txt
@@ -213,7 +213,7 @@ if (WIN32)  # Windows puts DLLs in bin/CONFIG/
   set(shared_lib_dir "/bin")
 else()  # Other Unix systems
   set(shared_lib_dir "/lib")
-  set(lib_dir_suffix "${MAPTK_LIB_SUFFIX}")
+  set(lib_dir_suffix "${LIB_SUFFIX}")
 endif()
 
 if (CMAKE_CONFIGURATION_TYPES)
@@ -240,7 +240,7 @@ target_compile_definitions(maptk_apm
     # For plugin manager
     "SHARED_LIB_SUFFIX=\"${CMAKE_SHARED_MODULE_SUFFIX}\""
     "USE_BUILD_PLUGIN_DIR=${MAPTK_USE_BUILD_PLUGIN_DIR}"
-    "DEFAULT_PLUGIN_DIR_BUILD=\"${MAPTK_BINARY_DIR}${shared_lib_dir}${config_subdir}/maptk\""
+    "DEFAULT_PLUGIN_DIR_BUILD=\"${MAPTK_BINARY_DIR}${shared_lib_dir}${lib_dir_suffix}${config_subdir}/maptk\""
     "DEFAULT_PLUGIN_DIR_INSTALL=\"${CMAKE_INSTALL_PREFIX}${shared_lib_dir}${lib_dir_suffix}/maptk\""
     # For static interface
     "MAPTK_ENABLE_OPENCV=${MAPTK_ENABLE_OPENCV}"

--- a/maptk/algo/algorithm.h
+++ b/maptk/algo/algorithm.h
@@ -62,7 +62,7 @@ typedef boost::shared_ptr<algorithm> algorithm_sptr;
 class MAPTK_LIB_EXPORT algorithm
 {
 public:
-  virtual ~algorithm() {}
+  virtual ~algorithm() MAPTK_DEFAULT_DTOR;
 
   /// Return the name of this algorithm
   virtual std::string type_name() const = 0;
@@ -235,7 +235,7 @@ public:
   /// Shared pointer type of the templated maptk::algorithm_def class
   typedef boost::shared_ptr<Self> base_sptr;
 
-  virtual ~algorithm_def() {}
+  virtual ~algorithm_def() MAPTK_DEFAULT_DTOR;
 
   /// Register instances of this algorithm with a given registrar
   static bool register_instance(registrar &reg, base_sptr inst);
@@ -350,7 +350,7 @@ public:
   /// shared pointer type of this impl's base maptk::algorithm_def class.
   typedef boost::shared_ptr<Base> base_sptr;
 
-  virtual ~algorithm_impl() {}
+  virtual ~algorithm_impl() MAPTK_DEFAULT_DTOR;
 
   /// Returns a clone of this algorithm
   virtual algorithm_sptr clone() const

--- a/maptk/algo/image_io.h
+++ b/maptk/algo/image_io.h
@@ -59,7 +59,7 @@ class MAPTK_LIB_EXPORT image_io
   : public algorithm_def<image_io>
 {
 public:
-  virtual ~image_io() {}
+  virtual ~image_io() MAPTK_DEFAULT_DTOR;
 
   /// Return the name of this algorithm
   static std::string static_type_name() { return "image_io"; }

--- a/maptk/camera.h
+++ b/maptk/camera.h
@@ -68,7 +68,7 @@ class camera
 {
 public:
   /// Destructor
-  virtual ~camera() {}
+  virtual ~camera() MAPTK_DEFAULT_DTOR;
 
   /// Create a clone of this camera object
   virtual camera_sptr clone() const = 0;

--- a/maptk/camera_map.h
+++ b/maptk/camera_map.h
@@ -52,7 +52,7 @@ public:
   typedef std::map<frame_id_t, camera_sptr> map_camera_t;
 
   /// Destructor
-  virtual ~camera_map() {}
+  virtual ~camera_map() MAPTK_DEFAULT_DTOR;
 
   /// Return the number of cameras in the map
   virtual size_t size() const = 0;

--- a/maptk/config.h.in
+++ b/maptk/config.h.in
@@ -94,6 +94,13 @@
 #endif
 
 
+// default dtor macro
+#if __cplusplus < 201103L
+# define MAPTK_DEFAULT_DTOR {}
+#else
+# define MAPTK_DEFAULT_DTOR = default
+#endif
+
 // no-throw macro
 #if __cplusplus < 201103L
 # define MAPTK_NOTHROW throw ()

--- a/maptk/descriptor.h
+++ b/maptk/descriptor.h
@@ -54,7 +54,7 @@ class descriptor
 {
 public:
   /// Destructor
-  virtual ~descriptor() {}
+  virtual ~descriptor() MAPTK_DEFAULT_DTOR;
 
   /// The number of elements of the underlying type
   virtual std::size_t size() const = 0;

--- a/maptk/descriptor_set.h
+++ b/maptk/descriptor_set.h
@@ -53,7 +53,7 @@ class descriptor_set
 {
 public:
   /// Destructor
-  virtual ~descriptor_set() {}
+  virtual ~descriptor_set() MAPTK_DEFAULT_DTOR;
 
   /// Return the number of descriptors in the set
   virtual size_t size() const = 0;

--- a/maptk/feature.h
+++ b/maptk/feature.h
@@ -59,7 +59,7 @@ class feature
 {
 public:
   /// Destructor
-  virtual ~feature() {}
+  virtual ~feature() MAPTK_DEFAULT_DTOR;
 
   /// Access the type info of the underlying data (double or float)
   virtual const std::type_info& data_type() const = 0;

--- a/maptk/feature_set.h
+++ b/maptk/feature_set.h
@@ -55,7 +55,7 @@ class feature_set
 {
 public:
   /// Destructor
-  virtual ~feature_set() {}
+  virtual ~feature_set() MAPTK_DEFAULT_DTOR;
 
   /// Return the number of features in the set
   virtual size_t size() const = 0;

--- a/maptk/homography.h
+++ b/maptk/homography.h
@@ -67,7 +67,7 @@ class homography
 {
 public:
   /// Destructor
-  virtual ~homography() {}
+  virtual ~homography() MAPTK_DEFAULT_DTOR;
 
   /// Create a clone of this homography object, returning as smart pointer
   /**

--- a/maptk/homography_f2w.h
+++ b/maptk/homography_f2w.h
@@ -60,6 +60,9 @@ public:
   /// Copy Constructor
   f2w_homography( f2w_homography const &h );
 
+  /// Destructor
+  virtual ~f2w_homography() MAPTK_DEFAULT_DTOR;
+
   /// Get the homography transformation
   virtual homography_sptr homography() const;
 

--- a/maptk/image_container.h
+++ b/maptk/image_container.h
@@ -58,7 +58,7 @@ class image_container
 public:
 
   /// Destructor
-  virtual ~image_container() {}
+  virtual ~image_container() MAPTK_DEFAULT_DTOR;
 
   /// The size of the image data in bytes
   /**

--- a/maptk/landmark.h
+++ b/maptk/landmark.h
@@ -66,7 +66,7 @@ class landmark
 {
 public:
   /// Destructor
-  virtual ~landmark() {}
+  virtual ~landmark() MAPTK_DEFAULT_DTOR;
 
   /// Create a clone of this landmark object
   virtual landmark_sptr clone() const = 0;

--- a/maptk/landmark_map.h
+++ b/maptk/landmark_map.h
@@ -52,7 +52,7 @@ public:
   typedef std::map<landmark_id_t, landmark_sptr> map_landmark_t;
 
   /// Destructor
-  virtual ~landmark_map() {}
+  virtual ~landmark_map() MAPTK_DEFAULT_DTOR;
 
   /// Return the number of landmarks in the map
   virtual size_t size() const = 0;

--- a/maptk/match_set.h
+++ b/maptk/match_set.h
@@ -36,6 +36,7 @@
 #ifndef MAPTK_MATCH_SET_H_
 #define MAPTK_MATCH_SET_H_
 
+#include <maptk/config.h>
 
 #include <vector>
 #include <boost/shared_ptr.hpp>
@@ -51,7 +52,7 @@ class match_set
 {
 public:
   /// Destructor
-  virtual ~match_set() {}
+  virtual ~match_set() MAPTK_DEFAULT_DTOR;
 
   /// Return the number of matches in the set
   virtual size_t size() const = 0;

--- a/maptk/plugins/core/close_loops_bad_frames_only.h
+++ b/maptk/plugins/core/close_loops_bad_frames_only.h
@@ -73,7 +73,7 @@ public:
   close_loops_bad_frames_only(const close_loops_bad_frames_only&);
 
   /// Destructor
-  virtual ~close_loops_bad_frames_only() {}
+  virtual ~close_loops_bad_frames_only() MAPTK_DEFAULT_DTOR;
 
   /// Return the name of this implementation
   virtual std::string impl_name() const { return "bad_frames_only"; }

--- a/maptk/plugins/core/close_loops_multi_method.h
+++ b/maptk/plugins/core/close_loops_multi_method.h
@@ -71,7 +71,7 @@ public:
   close_loops_multi_method(const close_loops_multi_method&);
 
   /// Destructor
-  virtual ~close_loops_multi_method() {}
+  virtual ~close_loops_multi_method() MAPTK_DEFAULT_DTOR;
 
   /// Return the name of this implementation
   virtual std::string impl_name() const { return "multi_method"; }

--- a/maptk/track_set.h
+++ b/maptk/track_set.h
@@ -62,7 +62,7 @@ class MAPTK_LIB_EXPORT track_set
 {
 public:
   /// Destructor
-  virtual ~track_set() {}
+  virtual ~track_set() MAPTK_DEFAULT_DTOR;
 
   /// Return the number of tracks in the set
   virtual size_t size() const;


### PR DESCRIPTION
Fix a `-Wnon-virtual-dtor` warning. Make destructors trivial when possible (i.e. C++11). Normalize `LIB_SUFFIX` support. Mark Eigen includes as `SYSTEM` to suppress warnings from the same.