### PR TITLE
Fix plugin build and install paths on Windows

### DIFF
--- a/maptk/CMakeLists.txt
+++ b/maptk/CMakeLists.txt
@@ -209,12 +209,6 @@ target_link_libraries(maptk_apm maptk)
 
 # Configuring/Adding compile definitions to target
 # (so we can use generator expressions)
-if (WIN32)  # Windows puts DLLs in bin/CONFIG/
-  set(shared_lib_dir "/bin")
-else()  # Other Unix systems
-  set(shared_lib_dir "/lib")
-  set(lib_dir_suffix "${LIB_SUFFIX}")
-endif()
 
 if (CMAKE_CONFIGURATION_TYPES)
   set(config_subdir "/$<CONFIGURATION>")
@@ -240,8 +234,8 @@ target_compile_definitions(maptk_apm
     # For plugin manager
     "SHARED_LIB_SUFFIX=\"${CMAKE_SHARED_MODULE_SUFFIX}\""
     "USE_BUILD_PLUGIN_DIR=${MAPTK_USE_BUILD_PLUGIN_DIR}"
-    "DEFAULT_PLUGIN_DIR_BUILD=\"${MAPTK_BINARY_DIR}${shared_lib_dir}${lib_dir_suffix}${config_subdir}/maptk\""
-    "DEFAULT_PLUGIN_DIR_INSTALL=\"${CMAKE_INSTALL_PREFIX}${shared_lib_dir}${lib_dir_suffix}/maptk\""
+    "DEFAULT_PLUGIN_DIR_BUILD=\"${MAPTK_BINARY_DIR}/lib${LIB_SUFFIX}${config_subdir}/maptk\""
+    "DEFAULT_PLUGIN_DIR_INSTALL=\"${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/maptk\""
     # For static interface
     "MAPTK_ENABLE_OPENCV=${MAPTK_ENABLE_OPENCV}"
     "MAPTK_ENABLE_PROJ=${MAPTK_ENABLE_PROJ}"


### PR DESCRIPTION
Plugins are built as "modules" which means that they are built in
the library path (/lib) instead of the runtime path (/bin).  Other
shared libraries (DLLs) in Windows are built in the runtime path.
As a result, no distinction between Windows and other platforms
is needed regarding where to find plugins.