### PR TITLE
Add a "_plugin" suffix to the base name for plugins

### DIFF
--- a/CMake/utils/maptk-utils-targets.cmake
+++ b/CMake/utils/maptk-utils-targets.cmake
@@ -237,7 +237,8 @@ endfunction()
 #
 # This generates a small MODULE library that exposes the required C interface
 # function to be picked up by the algorithm plugin manager. This library is set
-# to install into the .../maptk subdirectory.
+# to install into the .../maptk subdirectory and adds a _plugin suffix to the
+# base library name.
 #
 # Additional source files may be specified after the base library if the
 # registration interface implementation is separate from the base library.
@@ -276,7 +277,7 @@ function(maptk_create_plugin base_lib)
       PROPERTIES
         PREFIX        ""
         SUFFIX        ${CMAKE_SHARED_MODULE_SUFFIX}
-        OUTPUT_NAME   ${base_lib}
+        OUTPUT_NAME   ${base_lib}_plugin
       )
 
     add_dependencies(all-plugins maptk-plugin-${base_lib})


### PR DESCRIPTION
It was found to be problematic, especially on Windows, for the base
library and plugin to have the same name but be in different paths.
The Windows LoadLibrary call would load the plugin, then search for
the base library of the same name and find the plugin again because
the first search path was the plugin directory.