### PR TITLE
Remove automatically adding the /MP flag for msvc build

### DIFF
--- a/CMake/maptk-flags-msvc.cmake
+++ b/CMake/maptk-flags-msvc.cmake
@@ -9,7 +9,6 @@ if (NOT MAPTK_ENABLE_DLL_WARNINGS)
 endif()
 
 maptk_check_compiler_flag(/W3)
-maptk_check_compiler_flag(/MP)
 
 # Disable deprication warnings for standard C and STL functions in VS2005 and
 # later.


### PR DESCRIPTION
Using VS 2013, testing the flag is now causing CMake to hang during
the configure phase. Seems likely that a recent Microsoft update
is causing this since it hadn't been an issue. Regardless, it
generally isn't a good idea to automatically add this flag.