### PR TITLE
Prevent '/' from appearing in the safeflag

### DIFF
--- a/CMake/maptk-flags.cmake
+++ b/CMake/maptk-flags.cmake
@@ -14,6 +14,7 @@ define_property(GLOBAL PROPERTY MAPTK_CXX_FLAGS
 # Helper function for adding compiler flags
 function(maptk_check_compiler_flag flag)
   string(REPLACE "+" "plus" safeflag "${flag}")
+  string(REPLACE "/" "slash" safeflag "${safeflag}")
   check_cxx_compiler_flag("${flag}" "has_compiler_flag-${safeflag}")
   if( ${has_compiler_flag-${safeflag}} )
     set_property(GLOBAL APPEND PROPERTY MAPTK_CXX_FLAGS "${flag}")


### PR DESCRIPTION
safeflag (with some prepended text) is set as a preprocessor
definition. In the case of "/MP" and VS 2013, this was causing
the compile test to hang indefinitely.