### PR TITLE
Remove apparently spurious self-dependency

### DIFF
--- a/maptk/CMakeLists.txt
+++ b/maptk/CMakeLists.txt
@@ -81,4 +81,4 @@ endif()
 ###
 # Marking source root for documentation generation
 #
-kwiver_create_doxygen( maptk "${CMAKE_CURRENT_LIST_DIR}" "MAP-Tk")
+kwiver_create_doxygen( maptk "${CMAKE_CURRENT_LIST_DIR}" )


### PR DESCRIPTION
Remove doxygen tag dependency of `"maptk"` documentation on the `"MAP-Tk"` tags. There doesn't seem to be anything that would ever create this, and it results in a broken build graph when (API) documentation is enabled. (This seems to be a new development since switching to Vital. Not clear why it was working before.)

At any rate, it seems suspicious that the documentation depends on "its own" tags, and more likely that the specified dependency is an accident.