### PR TITLE
Corrected method of calculating size of image memory.

### DIFF
--- a/doc/rel_notes/0.7.0.txt
+++ b/doc/rel_notes/0.7.0.txt
@@ -177,6 +177,10 @@ Tests
 Fixes since v0.6.0
 -------------------------------
 
+OpenCV Plugin
+
+  * Fixed error where the size of OCV image memory was incorrectly calculated.
+
 Tests
 
   * Renamed the tests for the main library from "test_core" to "test_maptk"

--- a/maptk/plugins/ocv/mat_image_memory.cxx
+++ b/maptk/plugins/ocv/mat_image_memory.cxx
@@ -52,7 +52,7 @@ mat_image_memory
   assert(m.depth() == CV_8U);
   assert(!m.allocator);
   CV_XADD(this->mat_refcount_, 1);
-  size_ = sizeof(m.data);
+  size_ = m.rows * m.step;
 }
 
 


### PR DESCRIPTION
Fix image size calculation for OCV mat based images.