### PR TITLE
Added missing target dependency in CMakeLists.txt

### DIFF
--- a/maptk/CMakeLists.txt
+++ b/maptk/CMakeLists.txt
@@ -62,6 +62,7 @@ kwiver_add_library(
   ${maptk_public_headers}
   ${maptk_sources}
   )
+add_dependencies(maptk configure-config.h)
 target_link_libraries(maptk vital ${Boost_LIBRARIES} )
 
 


### PR DESCRIPTION
This was missing because of the switch to using kwiver_add_library
instead of maptk_add_library, which added the dependency automatically.