### PR TITLE
Set CMake policy for CMP0054 to NEW.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(MAPTK)
 ###
 # CMake policies
 #
-cmake_policy(SET CMP0054 NEW)
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 
 ###
 # Versioning

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 2.8.11)
 project(MAPTK)
 
 ###
+# CMake policies
+#
+cmake_policy(SET CMP0054 NEW)
+
+###
 # Versioning
 #
 set(MAPTK_VERSION_MAJOR 0)


### PR DESCRIPTION
This is to avoid the warning:
Make Warning (dev) at maptk/CMakeLists.txt:170 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "MSVC" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.