### PR TITLE
Switch to new Travis CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,42 @@
 #Travis CI configuration for MAP-Tk
 # See http://travis-ci.org/Kitware/maptk/
 
+sudo: false
+
 language: cpp
 compiler:
   - gcc
   - clang
 
-before_install:
-  # CMake in Ubuntu 12.04 is too old. Get a newer version from this PPA
-  - sudo apt-add-repository -y ppa:smspillaz/cmake-2.8.12
-  # Ubuntu 12.04 only provides Boost 1.46 and 1.48, we need > 1.50
-  # so add this PPA to provide newer Boost
-  - sudo apt-add-repository -y ppa:boost-latest/ppa
-  # Eigen in Ubuntu 12.04 is too old.  Get a newer version from this PPA
-  - sudo apt-add-repository -y ppa:liggghts-dev/external
-  # OpenCV in Ubuntu 12.04 is too old.  Get a newer version from this PPA
-  - sudo apt-add-repository -y ppa:thedsweb/yawls-opencv
-  # VXL 1.14 in Unbuntu 12.04 is too old. Get backport of VXL 1.17 from here
-  - sudo apt-add-repository -y ppa:matt-leotta/vxl
-  - sudo apt-get update -qq
+cache:
+  directories:
+  - $HOME/deps
 
-install:
-  - sudo apt-get install -y cmake cmake-data libproj-dev libeigen3-dev
-  - sudo apt-get install -y libboost1.55-all-dev
-  - sudo apt-get install -y libopencv-dev
-  - sudo apt-get install -y python3-dev python3-numpy python-dev python-numpy
-  - sudo apt-get install -y libvxl1-dev
-  # The Ubuntu VXL package has a bug in which it links to libgeotiff at
-  # the wrong location, so add a sym-link to work around.
-  - sudo ln -s /usr/lib/libgeotiff.so.2 /usr/lib/libgeotiff.so
+before_script:
+  - bash .travis/install-deps.sh
+
+addons:
+  apt:
+    sources:
+    - boost-latest
+    packages:
+    - libproj-dev
+    - libboost1.55-all-dev
+    - libgl1-mesa-dev
+    - libxt-dev
+    - libqt4-dev
 
 script:
+  - export PATH=$HOME/deps/bin:$PATH
   - mkdir build
   - cd build
   - cmake -DMAPTK_ENABLE_PROJ:BOOL=ON
           -DMAPTK_ENABLE_OPENCV:BOOL=ON
-          -DMAPTK_ENABLE_VXL:BOOL=ON
+          -DMAPTK_ENABLE_VXL:BOOL=OFF
+          -DMAPTK_ENABLE_CERES:BOOL=ON
+          -DMAPTK_ENABLE_GUI:BOOL=ON
           -DMAPTK_ENABLE_TESTING:BOOL=ON
+          -DEIGEN_INCLUDE_DIR:PATH=$HOME/deps/include/eigen3
           ../
-  - make
+  - make -j2
   - ctest

--- a/.travis/install-deps.sh
+++ b/.travis/install-deps.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -e
+
+export PATH=$HOME/deps/bin:$PATH
+HASH_DIR=$HOME/deps/hashes
+mkdir -p $HASH_DIR
+
+# check if directory is cached
+if [ ! -f "$HOME/deps/bin/cmake" ]; then
+  cd /tmp
+  wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.sh
+  bash cmake-3.4.0-Linux-x86_64.sh --skip-license --prefix="$HOME/deps/"
+else
+  echo 'Using cached CMake directory.';
+fi
+
+FLETCH_URL=https://github.com/Kitware/fletch.git
+FLETCH_RHASH=`git ls-remote -h $FLETCH_URL master | cut -f1`
+FLETCH_HASH_FILE=$HASH_DIR/fletch.sha
+echo "Current Fletch Hash: $FLETCH_RHASH"
+if [ -f $FLETCH_HASH_FILE ] && grep -q $FLETCH_RHASH $FLETCH_HASH_FILE ; then
+  echo "Using cached Fletch build: `cat $FLETCH_HASH_FILE`"
+else
+  if [ -f $FLETCH_HASH_FILE ]; then
+    echo "Cached Fletch build is not current: `cat $FLETCH_HASH_FILE`"
+  else
+    echo "No cached Fletch build"
+  fi
+  cd /tmp
+  git clone https://github.com/Kitware/fletch.git fletch/source
+  mkdir fletch/build
+  cd fletch/build
+  cmake ../source \
+        -DCMAKE_BUILD_TYPE=Release \
+        -Dfletch_ENABLE_Eigen=ON \
+        -Dfletch_ENABLE_Ceres=ON \
+        -Dfletch_ENABLE_SuiteSparse=ON \
+        -Dfletch_ENABLE_OpenCV=ON \
+        -Dfletch_ENABLE_VTK=ON
+  make -j2
+  cp -r install/* $HOME/deps/
+  echo $FLETCH_RHASH > $FLETCH_HASH_FILE
+fi
+
+
+VITAL_URL=https://github.com/Kitware/vital.git
+VITAL_RHASH=`git ls-remote -h $VITAL_URL master | cut -f1`
+VITAL_HASH_FILE=$HASH_DIR/vital.sha
+echo "Current Vital Hash: $VITAL_RHASH"
+if [ -f $VITAL_HASH_FILE ] && grep -q $VITAL_RHASH $VITAL_HASH_FILE; then
+  echo "Using cached Vital build: `cat $VITAL_HASH_FILE`"
+else
+  if [ -f $VITAL_HASH_FILE ]; then
+    echo "Cached Vital build is not current: `cat $VITAL_HASH_FILE`"
+  else
+    echo "No cached Vital build"
+  fi
+  cd /tmp
+  git clone $VITAL_URL vital/source
+  mkdir vital/build
+  cd vital/build
+  cmake ../source \
+        -DCMAKE_INSTALL_PREFIX=$HOME/deps/ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DVITAL_ENABLE_C_LIB=ON
+  make -j2
+  make install
+  echo $VITAL_RHASH > $VITAL_HASH_FILE
+fi
+
+
+QTE_URL=https://github.com/Kitware/qtextensions.git
+QTE_RHASH=`git ls-remote -h $QTE_URL master | cut -f1`
+QTE_HASH_FILE=$HASH_DIR/qtextensions.sha
+echo "Current QtExtensions Hash: $QTE_RHASH"
+if [ -f $QTE_HASH_FILE ] && grep -q $QTE_RHASH $QTE_HASH_FILE; then
+  echo "Using cached QtExtenions build: `cat $QTE_HASH_FILE`"
+else
+  if [ -f $QTE_HASH_FILE ]; then
+    echo "Cached QtExtenions build is not current: `cat $QTE_HASH_FILE`"
+  else
+    echo "No cached QtExtenions build"
+  fi
+  cd /tmp
+  git clone $QTE_URL qtextensions/source
+  mkdir qtextensions/build
+  cd qtextensions/build
+  cmake ../source \
+        -DCMAKE_INSTALL_PREFIX=$HOME/deps/ \
+        -DCMAKE_BUILD_TYPE=Release
+  make -j2
+  make install
+  echo $QTE_RHASH > $QTE_HASH_FILE
+fi


### PR DESCRIPTION
This patch changes the way dependencies are built for MAP-Tk.
We now use the new container-based infrastructure which is faster
but limits packages with can install with apt.  Instead, many packages
are built from source and then cached for future builds.

At this point the CI tests are only building a subset of the MAP-Tk components.