### PR TITLE
Add logger to copy/constructor.

### DIFF
--- a/maptk/plugins/vxl/image_io.cxx
+++ b/maptk/plugins/vxl/image_io.cxx
@@ -70,7 +70,8 @@ public:
   priv(const priv& other)
   : auto_stretch(other.auto_stretch),
     manual_stretch(other.manual_stretch),
-    intensity_range(other.intensity_range)
+    intensity_range(other.intensity_range),
+    m_logger(other.m_logger)
   {
   }
 


### PR DESCRIPTION
This patch prevents a segfault the first time we try log a message.

The copy constructor for the image_io pimpl is missing the copy of the logging member.