### PR TITLE
Add the maptk version to the exported config file.

### DIFF
--- a/CMake/maptk-config.cmake.in
+++ b/CMake/maptk-config.cmake.in
@@ -4,6 +4,7 @@ set(CMAKE_MODULE_PATH "@module_path@" ${CMAKE_MODULE_PATH})
 # MAPTK include directory
 set(MAPTK_INCLUDE_DIRS "@MAPTK_SOURCE_DIR@" "@MAPTK_BINARY_DIR@" "@EIGEN3_INCLUDE_DIR@")
 set(MAPTK_LIBRARIES @maptk_libs@)
+set(MAPTK_VERSION @MAPTK_VERSION@)
 
 # Export definitions for MAPTK to be used from find_package
 include("${CMAKE_CURRENT_LIST_DIR}/maptk-config-targets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ maptk_configure_file(maptk-config
   MAPTK_SOURCE_DIR
   MAPTK_BINARY_DIR
   EIGEN3_INCLUDE_DIR
+  MAPTK_VERSION
   maptk_libs
   module_path
   )


### PR DESCRIPTION
Export the MAP-Tk version so consumers can verify.