### PR TITLE
Make the link to ceres private.

### DIFF
--- a/maptk/plugins/ceres/CMakeLists.txt
+++ b/maptk/plugins/ceres/CMakeLists.txt
@@ -32,7 +32,7 @@ kwiver_add_library( maptk_ceres
   )
 target_link_libraries( maptk_ceres
   PUBLIC               maptk
-                       ceres
+  PRIVATE              ceres
   )
 
 maptk_create_plugin( maptk_ceres


### PR DESCRIPTION
Private linkage prevents the ceres dependency from leaking into projects that use Map-TK, but don't really need to care about linking ceres.