### PR TITLE
Fix vanishing ground plane

### DIFF
--- a/doc/rel_notes/0.8.1.txt
+++ b/doc/rel_notes/0.8.1.txt
@@ -28,6 +28,11 @@ MAP-Tk GUI
    The GUI now catches config exception and prints a warning message.  This
    is a temporary solution until a proper error dialog is implemented.
 
+ * Fixed an issue with the ground plane disappearing after loading data that
+   did not include landmarks.  The ground plane now uses the cameras for scale
+   when only cameras are in the world view and no longer disappears when the
+   only data loaded is in the image view.
+
 Tools
 
  * Fixed an issue with converting POS filenames to KRTD in the pos2krtd tool.

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -638,6 +638,13 @@ void WorldView::updateScale()
     d->landmarkActor->GetMapper()->Update();
     bbox.AddBounds(d->landmarkActor->GetBounds());
 
+    // If landmarks are not valid, then get ground scale from the cameras
+    if (!bbox.IsValid())
+    {
+      // Add camera centers
+      bbox.AddBounds(d->cameraRep->GetPathActor()->GetBounds());
+    }
+
     // Update ground plane scale
     auto const groundScale =
       1.5 * qMax(qMax(qAbs(bbox.GetBound(0)), qAbs(bbox.GetBound(1))),

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -643,11 +643,6 @@ void WorldView::updateScale()
       1.5 * qMax(qMax(qAbs(bbox.GetBound(0)), qAbs(bbox.GetBound(1))),
                  qMax(qAbs(bbox.GetBound(2)), qAbs(bbox.GetBound(3))));
 
-    d->groundPlane->SetOrigin(-groundScale, -groundScale, 0.0);
-    d->groundPlane->SetPoint1(+groundScale, -groundScale, 0.0);
-    d->groundPlane->SetPoint2(-groundScale, +groundScale, 0.0);
-    d->groundPlane->Modified();
-
     // Add camera centers
     bbox.AddBounds(d->cameraRep->GetPathActor()->GetBounds());
 
@@ -660,6 +655,12 @@ void WorldView::updateScale()
 
       // Update camera scale
       d->cameraOptions->setBaseCameraScale(cameraScale);
+
+      // Update the ground scale
+      d->groundPlane->SetOrigin(-groundScale, -groundScale, 0.0);
+      d->groundPlane->SetPoint1(+groundScale, -groundScale, 0.0);
+      d->groundPlane->SetPoint2(-groundScale, +groundScale, 0.0);
+      d->groundPlane->Modified();
     }
 
     d->scaleDirty = false;


### PR DESCRIPTION
Fixed an issue with the ground plane disappearing after loading data that did not include landmarks.  The ground plane now uses the cameras for scale when only cameras are in the world view and no longer disappears when the only data loaded is in the image view.