### PR TITLE
Avoid adding keyframes on frames with few matchable features.

### DIFF
--- a/maptk/plugins/core/close_loops_keyframe.cxx
+++ b/maptk/plugins/core/close_loops_keyframe.cxx
@@ -361,6 +361,8 @@ close_loops_keyframe
                            << " has "<< num_matched << " matches and "
                            << num_linked << " joined tracks");
   }
+  // divide by number of matched frames to get the average
+  d_->frame_matches[frame_number] /= (frame_number - last_frame);
 
   // stitch with all previous keyframes
   for(auto kitr = d_->keyframes.rbegin(); kitr != d_->keyframes.rend(); ++kitr)
@@ -417,10 +419,14 @@ close_loops_keyframe
         max_id = hitr->first;
       }
     }
-    // create the new keyframe and clear the list of misses
-    LOG_INFO(d_->m_logger, "creating new keyframe on frame " << max_id);
-    d_->keyframes.push_back(max_id);
-    d_->keyframe_misses.clear();
+    // the new key frame must have the required number of matches on average
+    if( max_matches > static_cast<unsigned int>(d_->match_req) )
+    {
+      // create the new keyframe and clear the list of misses
+      LOG_INFO(d_->m_logger, "creating new keyframe on frame " << max_id);
+      d_->keyframes.push_back(max_id);
+      d_->keyframe_misses.clear();
+    }
   }
 
   return input;


### PR DESCRIPTION
This change ensures that the average number of matches on the selected
new keyframe is greater than the match requirement.  This avoids
creating keyframes on unmatchable textureless frames.