### PR TITLE
"krtd_clean_up" option 

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(maptk_pos2krtd
 
 kwiver_add_executable(maptk_bundle_adjust_tracks bundle_adjust_tracks.cxx)
 target_link_libraries(maptk_bundle_adjust_tracks
-  PRIVATE             maptk vital_apm kwiversys
+  PRIVATE             maptk vital_apm kwiversys boost_filesystem boost_system
   )
 
 kwiver_add_executable(maptk_analyze_tracks analyze_tracks.cxx)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(maptk_pos2krtd
 
 kwiver_add_executable(maptk_bundle_adjust_tracks bundle_adjust_tracks.cxx)
 target_link_libraries(maptk_bundle_adjust_tracks
-  PRIVATE             maptk vital_apm kwiversys boost_filesystem boost_system
+  PRIVATE             maptk vital_apm kwiversys
   )
 
 kwiver_add_executable(maptk_analyze_tracks analyze_tracks.cxx)

--- a/tools/bundle_adjust_tracks.cxx
+++ b/tools/bundle_adjust_tracks.cxx
@@ -180,6 +180,9 @@ static kwiver::vital::config_block_sptr default_config()
                     "when updating cameras. This option is only relevent if a "
                     "value is give to the input_pos_files option.");
 
+
+      config->set_value("krtd_clean_up", "false",
+                        "Delete krtd files present into output_krtd_dir before launching the bundle adjustment.");
   kwiver::vital::algo::bundle_adjust::get_nested_algo_configuration("bundle_adjuster", config,
                                                      kwiver::vital::algo::bundle_adjust_sptr());
   kwiver::vital::algo::initialize_cameras_landmarks
@@ -1018,6 +1021,22 @@ static int maptk_main(int argc, char const* argv[])
   //
   // Write the output KRTD files
   //
+  if (config->get_value<bool>("krtd_clean_up") )
+  {
+    std::cout << "Cleaning " << config->get_value<std::string>("output_krtd_dir") << " before writing new files." << std::endl;
+
+    std::ifstream framelist(config->get_value<std::string>("image_list_file"));
+    std::string filePath, krtdFile;
+
+    while (framelist >> filePath)
+    {
+      krtdFile = ST::GetFilenameWithoutExtension(filePath) + ".krtd";
+
+      ST::RemoveFile(config->get_value<std::string>("output_krtd_dir") + krtdFile);
+    }
+
+  }
+
   if( config->has_value("output_krtd_dir") )
   {
     std::cerr << "Writing output KRTD files" << std::endl;

--- a/tools/bundle_adjust_tracks.cxx
+++ b/tools/bundle_adjust_tracks.cxx
@@ -41,8 +41,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-
 #include <vital/vital_foreach.h>
 #include <vital/config/config_block.h>
 #include <vital/config/config_block_io.h>
@@ -1030,16 +1028,14 @@ static int maptk_main(int argc, char const* argv[])
               << config->get_value<std::string>("output_krtd_dir")
               << " before writing new files." << std::endl;
 
-    boost::filesystem::path p(config->get_value<std::string>("output_krtd_dir"));
-    boost::filesystem::directory_iterator end_iter;
+    kwiver::vital::path_t krtd_dir = config->get_value<std::string>("output_krtd_dir");
+    std::vector<kwiver::vital::path_t> files = files_in_dir(krtd_dir);
 
-    for( boost::filesystem::directory_iterator dir_iter(p);
-         dir_iter != end_iter; ++dir_iter)
+    for (int i = 0; i < files.size(); ++i)
     {
-      if (boost::filesystem::is_regular_file(dir_iter->status())
-          && boost::filesystem::extension(dir_iter->path()) == ".krtd")
+      if (ST::GetFilenameExtension(files[i]) == ".krtd")
       {
-        boost::filesystem::remove(dir_iter->path());
+        ST::RemoveFile(files[i]);
       }
     }
 

--- a/tools/bundle_adjust_tracks.cxx
+++ b/tools/bundle_adjust_tracks.cxx
@@ -1033,7 +1033,7 @@ static int maptk_main(int argc, char const* argv[])
 
     for (int i = 0; i < files.size(); ++i)
     {
-      if (ST::GetFilenameExtension(files[i]) == ".krtd")
+      if (ST::GetFilenameLastExtension(files[i]) == ".krtd")
       {
         ST::RemoveFile(files[i]);
       }


### PR DESCRIPTION
Added a "krtd_clean_up" option in the bundle adjuster config file which can be turned to true in order to remove all the *.krtd files present in the "output_krtd_dir" directory before writing the bundle adjusted *.krd files. It's useful when the bundle adjuster is run several times and doesn't generate the same amount of *.krtd files each times.