### PR TITLE
Export scene to WebGL

### DIFF
--- a/doc/rel_notes/0.9.0.txt
+++ b/doc/rel_notes/0.9.0.txt
@@ -44,6 +44,11 @@ Tools
  * Updated the bundle_adjust_tracks tool to use the configurable abstract
    algorithm for canonical transform.
 
+ * Added an option to the bundle_adjust_tracks tool to remove all the KRTD
+   files from the output directory before writing new ones.  This is useful
+   when only a subset of cameras are computed and we do not want a mix of
+   old and new camera files.
+
 
 Fixes since v0.8.0
 -------------------------------

--- a/doc/rel_notes/0.9.0.txt
+++ b/doc/rel_notes/0.9.0.txt
@@ -52,5 +52,9 @@ Tools
  * Added an option to display the world axes around the visible geometry.
    This option can be enabled and disabled in the "View" menu.
 
+ * Added an option to export the current scene to webGL. This option is only
+   available if VTK was built with the option Module_vtkWebGLExporter turned on.
+   This option can then be found in the "File > Export" menu.
+
 Fixes since v0.8.0
 -------------------------------

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(qtExtensions REQUIRED)
 include(${qtExtensions_USE_FILE})
 
 find_package(VTK 6.2 REQUIRED)
+
 include(${VTK_USE_FILE})
 
 #
@@ -21,6 +22,12 @@ include_directories(
   ${MAPTK_SOURCE_DIR}
   ${MAPTK_BINARY_DIR}
 )
+
+if(vtkWebGLExporter_LOADED)
+  message(STATUS "Module vtkWebGLExporter loaded, wekGL export enabled")
+  add_definitions(-DVTKWEBGLEXPORTER)
+endif()
+
 
 set(gui_am_ui
   CameraView.ui
@@ -144,11 +151,14 @@ target_link_libraries(mapgui
   vtkRenderingCore
   vtkCommonCore
   vtksys
-  vtkWebGLExporter
   qtExtensions
   ${QT_QTMAIN_LIBRARY}
   ${QT_LIBRARIES}
 )
+
+if(vtkWebGLExporter_LOADED)
+  target_link_libraries(mapgui vtkWebGLExporter)
+endif()
 
 if(APPLE)
   file(STRINGS "${MAPTK_SOURCE_DIR}/LICENSE" copyright_line

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -144,6 +144,7 @@ target_link_libraries(mapgui
   vtkRenderingCore
   vtkCommonCore
   vtksys
+  vtkWebGLExporter
   qtExtensions
   ${QT_QTMAIN_LIBRARY}
   ${QT_LIBRARIES}

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -630,6 +630,9 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 
   this->setSlideDelay(d->UI.slideDelay->value());
 
+  connect(d->UI.actionWebGLScene, SIGNAL(triggered(bool)),
+          this, SLOT(exportWebGLScene()));
+
   // Set up UI persistence and restore previous state
   auto const sdItem = new qtUiState::Item<int, QSlider>(
     d->UI.slideDelay, &QSlider::value, &QSlider::setValue);
@@ -1148,6 +1151,20 @@ void MainWindow::showUserManual()
       this, "Not found",
       "The user manual could not be located. Please check your installation.");
   }
+}
+
+//-----------------------------------------------------------------------------
+void MainWindow::exportWebGLScene()
+{
+  QTE_D();
+
+  auto const path = QFileDialog::getSaveFileName(
+    this, "Export Scene to WebGL", QString(),
+    "WebGL scene file (*.html);;"
+    "All Files (*)");
+
+   d->UI.worldView->exportWebGLScene(path);
+
 }
 
 //END MainWindow

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -634,6 +634,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   this->setSlideDelay(d->UI.slideDelay->value());
 
 #ifdef VTKWEBGLEXPORTER
+  d->UI.actionWebGLScene->setVisible(true);
   connect(d->UI.actionWebGLScene, SIGNAL(triggered(bool)),
           this, SLOT(exportWebGLScene()));
 #endif

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -630,9 +630,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 
   this->setSlideDelay(d->UI.slideDelay->value());
 
+#ifdef VTKWEBGLEXPORTER
   connect(d->UI.actionWebGLScene, SIGNAL(triggered(bool)),
           this, SLOT(exportWebGLScene()));
-
+#endif
   // Set up UI persistence and restore previous state
   auto const sdItem = new qtUiState::Item<int, QSlider>(
     d->UI.slideDelay, &QSlider::value, &QSlider::setValue);
@@ -768,6 +769,10 @@ void MainWindow::loadProject(QString const& path)
       }
     }
   }
+
+#ifdef VTKWEBGLEXPORTER
+  d->UI.actionWebGLScene->setEnabled(true);
+#endif
 
   d->UI.worldView->resetView();
 }
@@ -1153,6 +1158,7 @@ void MainWindow::showUserManual()
   }
 }
 
+#ifdef VTKWEBGLEXPORTER
 //-----------------------------------------------------------------------------
 void MainWindow::exportWebGLScene()
 {
@@ -1163,8 +1169,9 @@ void MainWindow::exportWebGLScene()
     "WebGL scene file (*.html);;"
     "All Files (*)");
 
-   d->UI.worldView->exportWebGLScene(path);
+  d->UI.worldView->exportWebGLScene(path);
 
 }
+#endif
 
 //END MainWindow

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -70,6 +70,8 @@ public slots:
   void showAboutDialog();
   void showUserManual();
 
+  void exportWebGLScene();
+
 protected slots:
   void setSlideDelay(int);
   void setSlideshowPlaying(bool);

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -70,7 +70,9 @@ public slots:
   void showAboutDialog();
   void showUserManual();
 
+#ifdef VTKWEBGLEXPORTER
   void exportWebGLScene();
+#endif
 
 protected slots:
   void setSlideDelay(int);

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>27</height>
     </rect>
    </property>
    <widget class="qtMenu" name="menuFile">
@@ -277,6 +277,9 @@
    </property>
   </action>
   <action name="actionWebGLScene">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>WebGL Scene...</string>
    </property>

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -284,6 +284,9 @@
    <property name="text">
     <string>WebGL Scene...</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionShowWorldAxes">
    <property name="checkable">

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -33,6 +33,8 @@
      </property>
      <addaction name="actionExportCameras"/>
      <addaction name="actionExportLandmarks"/>
+     <addaction name="separator"/>
+     <addaction name="actionWebGLScene"/>
     </widget>
     <addaction name="actionOpen"/>
     <addaction name="menuExport"/>
@@ -272,6 +274,11 @@
    </property>
    <property name="toolTip">
     <string>Change the background color of the views</string>
+   </property>
+  </action>
+  <action name="actionWebGLScene">
+   <property name="text">
+    <string>WebGL Scene...</string>
    </property>
   </action>
  </widget>

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -62,7 +62,10 @@
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnsignedIntArray.h>
 
-#include <vtkWebGLExporter.h>
+#ifdef VTKWEBGLEXPORTER
+  #include <vtkWebGLExporter.h>
+#endif
+
 #include <qtMath.h>
 
 #include <QtGui/QMenu>
@@ -682,10 +685,12 @@ void WorldView::updateScale()
   }
 }
 
+#ifdef VTKWEBGLEXPORTER
 //-----------------------------------------------------------------------------
 void WorldView::exportWebGLScene(QString const& path)
 {
   QTE_D();
+
 
   vtkNew<vtkWebGLExporter> exporter;
 
@@ -717,5 +722,5 @@ void WorldView::exportWebGLScene(QString const& path)
 
   exporter->exportStaticScene(d->renderWindow->GetRenderers(), width, height,
                               path.toStdString().c_str());
-
 }
+#endif

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -852,7 +852,7 @@ void WorldView::exportWebGLScene(QString const& path)
   }
 
   exporter->exportStaticScene(d->renderWindow->GetRenderers(), width, height,
-                              path.toStdString().c_str());
+                              qPrintable(path));
 
 }
 #endif

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -828,15 +828,15 @@ void WorldView::exportWebGLScene(QString const& path)
   int width = d->renderWindow->GetScreenSize()[0];
   int height = d->renderWindow->GetScreenSize()[1];
 
-  /** WARNING: This is a workaround. There's a bug in
+  /* WARNING: This is a workaround. There's a bug in
    * vtkWebGLPolyData->GetColorsFromPointData():
-   * the LookupTable->GetVectorMode() is passed instead of the GetMapper->GetColorMode. This bug is
-   * fixed in the last  version of VTK, but not in the 6.2 required by MapTK.
+   * the LookupTable->GetVectorMode() is passed instead of the GetMapper->GetColorMode.
+   * This bug is fixed in the latest version of VTK, but not in the 6.2 required by MapTK.
    * The workaround here is to force the LookupTable's VectorMode to
    * vtkScalarsToColors::RGBCOLORS if the Mapper's ColorMode equals
    * VTK_COLOR_MODE_DEFAULT or VTK_COLOR_MODE_DIRECT_SCALARS.
    *
-   * This workaround shall be removed when MapTK will be compatible with the last
+   * This workaround shall be removed when MapTK will be compatible with the latest
    * VTK version.
   */
   auto const actors = d->renderer->GetActors();

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -77,7 +77,10 @@ public slots:
   void viewToWorldFront();
   void viewToWorldBack();
 
+#ifdef VTKWEBGLEXPORTER
   void exportWebGLScene(QString const& path);
+#endif
+
 protected slots:
   void updateCameras();
   void updateScale();

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -77,6 +77,7 @@ public slots:
   void viewToWorldFront();
   void viewToWorldBack();
 
+  void exportWebGLScene(QString const& path);
 protected slots:
   void updateCameras();
   void updateScale();


### PR DESCRIPTION
Added an export scene to WebGL option. This feature create a *.html document which can be opened in a browser with the current scene in it. The objects displayed are those with a mapper (i. e. not the 2D objects such as the image). The objects colors are the ones in the mappers' lookup tables. 