### PR TITLE
Launch Plane Sweep Algorithm from GUI

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -32,12 +32,14 @@ set(gui_am_ui
 set(gui_ui
   ${gui_am_ui}
   AboutDialog.ui
+  OutputDialog.ui
   CameraOptions.ui
   DataColorOptions.ui
   DataFilterOptions.ui
   FeatureOptions.ui
   ImageOptions.ui
   PointOptions.ui
+  LaunchPlaneSweepView.ui
 )
 
 set(gui_resources
@@ -47,6 +49,7 @@ set(gui_resources
 
 set(gui_moc_headers
   AboutDialog.h
+  OutputDialog.h
   ActorColorButton.h
   CameraOptions.h
   CameraView.h
@@ -63,10 +66,12 @@ set(gui_moc_headers
   tools/BundleAdjustTool.h
   tools/CanonicalTransformTool.h
   tools/NeckerReversalTool.h
+  LaunchPlaneSweepView.h
 )
 
 set(gui_sources
   AboutDialog.cxx
+  OutputDialog.cxx
   ActorColorButton.cxx
   CameraOptions.cxx
   CameraView.cxx
@@ -90,6 +95,7 @@ set(gui_sources
   tools/BundleAdjustTool.cxx
   tools/CanonicalTransformTool.cxx
   tools/NeckerReversalTool.cxx
+  LaunchPlaneSweepView.cxx
 )
 
 maptk_use_appdata(

--- a/gui/LaunchPlaneSweepView.cxx
+++ b/gui/LaunchPlaneSweepView.cxx
@@ -159,7 +159,7 @@ void LaunchPlaneSweepView::compute()
 {
   QTE_D();
 
-  std::string pslPath = d->UI.lineEditPSLPath->text().toStdString();
+  QString pslPath = d->UI.lineEditPSLPath->text();
 
   d->args << "--debug";
 
@@ -188,7 +188,7 @@ void LaunchPlaneSweepView::compute()
   {
     if (this->children().at(i)->inherits("QCheckBox"))
     {
-      QCheckBox *child = (QCheckBox*) this->children().at(i);
+      QCheckBox *child = qobject_cast<QCheckBox*>(this->children().at(i));
 
       if (child->isChecked())
       {
@@ -197,19 +197,20 @@ void LaunchPlaneSweepView::compute()
     }
     else if (this->children().at(i)->inherits("QComboBox"))
     {
-      QComboBox *child = (QComboBox*) this->children().at(i);
+      QComboBox *child = qobject_cast<QComboBox*>(this->children().at(i));
 
       d->addArg(child, child->currentText().toStdString());
     }
     else if (this->children().at(i)->inherits("QSpinBox"))
     {
-      QSpinBox *child = (QSpinBox*) this->children().at(i);
+      QSpinBox *child = qobject_cast<QSpinBox*>(this->children().at(i));
 
       d->addArg(child,child->value());
     }
   }
 
-  d->addArg(d->UI.lineEditOutputDirectory,d->UI.lineEditOutputDirectory->text().toStdString());
+  d->addArg(d->UI.lineEditOutputDirectory,
+            d->UI.lineEditOutputDirectory->text().toStdString());
 
 
   d->dialog->show();
@@ -218,7 +219,7 @@ void LaunchPlaneSweepView::compute()
   runningState();
 
   d->psl->setProcessChannelMode(QProcess::MergedChannels);
-  d->psl->start(QString::fromStdString(pslPath),d->args);
+  d->psl->start(pslPath,d->args);
 }
 
 //-----------------------------------------------------------------------------
@@ -255,7 +256,7 @@ void LaunchPlaneSweepView::initialState()
   d->args.clear();
   for (int i = 0; i < this->children().size(); ++i) {
     if (this->children().at(i)->inherits("QWidget")) {
-      QWidget *child = (QWidget*) this->children().at(i);
+      QWidget *child = qobject_cast<QWidget*>(this->children().at(i));
       child->setEnabled(true);
     }
   }
@@ -285,7 +286,7 @@ void LaunchPlaneSweepView::runningState()
   {
     if (this->children().at(i)->inherits("QWidget"))
     {
-      QWidget *child = (QWidget*) this->children().at(i);
+      QWidget *child = qobject_cast<QWidget*>(this->children().at(i));
       child->setEnabled(false);
     }
   }

--- a/gui/LaunchPlaneSweepView.cxx
+++ b/gui/LaunchPlaneSweepView.cxx
@@ -139,14 +139,6 @@ void LaunchPlaneSweepView::setKrtdFolder(QString krtdFolder)
 }
 
 //-----------------------------------------------------------------------------
-void LaunchPlaneSweepView::setFramesFolder(QString framesFolder)
-{
-  QTE_D();
-
-  d->framesFolder = framesFolder;
-}
-
-//-----------------------------------------------------------------------------
 void LaunchPlaneSweepView::setLandmarksFile(QString landmarksFile)
 {
   QTE_D();
@@ -245,6 +237,26 @@ void LaunchPlaneSweepView::setFrameList(QString frameList)
   QTE_D();
 
   d->frameList = frameList;
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::setNumCam(int numCam)
+{
+  QTE_D();
+
+  d->UI.spinBoxFrameSample->setMaximum(numCam);
+  d->UI.spinBoxRefFrameStep->setMaximum(numCam);
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::initalizeValues(QString krtdFolder,
+                                           QString landmarksFile,
+                                           QString frameList, int numCam)
+{
+  setKrtdFolder(krtdFolder);
+  setLandmarksFile(landmarksFile);
+  setFrameList(frameList);
+  setNumCam(numCam);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/LaunchPlaneSweepView.cxx
+++ b/gui/LaunchPlaneSweepView.cxx
@@ -1,0 +1,302 @@
+/*ckwg +29
+ * Copyright 2015 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LaunchPlaneSweepView.h"
+
+#include "ui_LaunchPlaneSweepView.h"
+
+#include "OutputDialog.h"
+
+#include <qtUiState.h>
+#include <qtUiStateItem.h>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <QProcess>
+#include <QByteArray>
+
+///////////////////////////////////////////////////////////////////////////////
+
+//BEGIN LaunchPlaneSweepViewPrivate
+
+//-----------------------------------------------------------------------------
+class LaunchPlaneSweepViewPrivate
+{
+public:
+
+  Ui::LaunchPlaneSweepView UI;
+  qtUiState uiState;
+
+  QStringList args;
+
+  QProcess *psl;
+
+  std::string krtdFolder;
+  std::string framesFolder;
+  std::string frameList;
+  std::string landmarksFile;
+
+  void addArg(QWidget* item, std::string value="");
+  void addArg(QWidget *item, double value);
+
+  OutputDialog* dialog;
+};
+
+QTE_IMPLEMENT_D_FUNC(LaunchPlaneSweepView)
+
+//END LaunchPlaneSweepViewPrivate
+
+//BEGIN LaunchPlaneSweepView
+
+//-----------------------------------------------------------------------------
+LaunchPlaneSweepView::LaunchPlaneSweepView(QWidget* parent, Qt::WindowFlags flags)
+  : QWidget(parent, flags), d_ptr(new LaunchPlaneSweepViewPrivate)
+{
+  QTE_D();
+
+  this->setAttribute(Qt::WA_DeleteOnClose);
+
+  // Set up UI
+  d->UI.setupUi(this);
+
+  // Set up UI persistence and restore previous state
+  d->uiState.setCurrentGroup("LaunchPlaneSweepView");
+
+
+  // Set up signals/slots
+  connect(d->UI.pushButtonCompute, SIGNAL(clicked(bool)),
+          this, SLOT(compute()));
+
+  connect(d->UI.checkBoxDepthAuto, SIGNAL(toggled(bool)),
+          d->UI.doubleSpinBoxDepthMin, SLOT(setDisabled(bool)));
+
+
+  connect(d->UI.checkBoxDepthAuto, SIGNAL(toggled(bool)),
+          d->UI.doubleSpinBoxDepthMax, SLOT(setDisabled(bool)));
+
+  connect(d->UI.comboBoxMatchCost, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(enableColorMatching()));
+
+  d->dialog = new OutputDialog();
+
+  d->psl = new QProcess();
+
+  connect(d->psl, SIGNAL(readyRead()),
+         d->dialog, SLOT(ouputPSL()));
+
+  connect(d->psl, SIGNAL(finished(int)),
+         this, SLOT(initialState()));
+
+  connect(d->UI.pushButtonStop, SIGNAL(clicked(bool)),
+         d->psl, SLOT(kill()));
+}
+
+//-----------------------------------------------------------------------------
+LaunchPlaneSweepView::~LaunchPlaneSweepView()
+{
+  QTE_D();
+  d->uiState.save();
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::setKrtdFolder(std::string krtdFolder)
+{
+  QTE_D();
+
+  d->krtdFolder = "--krtdFolder="+krtdFolder;
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::setFramesFolder(std::string framesFolder)
+{
+  QTE_D();
+
+  d->framesFolder = framesFolder;
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::setLandmarksFile(std::string landmarksFile)
+{
+  QTE_D();
+
+  d->landmarksFile = "--landmarksPLY=" + landmarksFile;
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::compute()
+{
+  QTE_D();
+
+  std::string pslPath = d->UI.lineEditPSLPath->text().toStdString();
+
+  d->args << "--debug";
+
+  //Getting frame folder
+
+  std::ifstream frameList(d->frameList);
+  std::string framePath, frameFolder, imageListFile;
+
+  imageListFile = "--imageListFile=" + d->frameList;
+
+  frameList >> framePath;
+  frameFolder = framePath.substr(0,framePath.find_last_of("/"));
+
+  frameList.close();
+
+  frameFolder = "--frameFolder=" + frameFolder;
+
+  d->args <<  QString::fromStdString(frameFolder) ;
+  d->args << QString::fromStdString(d->krtdFolder);
+  d->args << QString::fromStdString(imageListFile);
+  d->args << QString::fromStdString(d->landmarksFile);
+
+  //Parsing arguments from form
+
+  for (int i = 0; i < this->children().size(); ++i)
+  {
+    if (this->children().at(i)->inherits("QCheckBox"))
+    {
+      QCheckBox *child = (QCheckBox*) this->children().at(i);
+
+      if (child->isChecked())
+      {
+        d->addArg(child);
+      }
+    }
+    else if (this->children().at(i)->inherits("QComboBox"))
+    {
+      QComboBox *child = (QComboBox*) this->children().at(i);
+
+      d->addArg(child, child->currentText().toStdString());
+    }
+    else if (this->children().at(i)->inherits("QSpinBox"))
+    {
+      QSpinBox *child = (QSpinBox*) this->children().at(i);
+
+      d->addArg(child,child->value());
+    }
+  }
+
+  d->addArg(d->UI.lineEditOutputDirectory,d->UI.lineEditOutputDirectory->text().toStdString());
+
+
+  d->dialog->show();
+  d->dialog->setOutputToDisplay(d->psl);
+
+  runningState();
+
+  d->psl->setProcessChannelMode(QProcess::MergedChannels);
+  d->psl->start(QString::fromStdString(pslPath),d->args);
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::enableColorMatching()
+{
+
+  QTE_D();
+
+  if (d->UI.comboBoxMatchCost->currentText().toStdString() == "SAD")
+  {
+    d->UI.checkBoxColorMatching->setEnabled(true);
+    d->UI.checkBoxColorMatching->setChecked(true);
+  }
+  else
+  {
+    d->UI.checkBoxColorMatching->setEnabled(false);
+    d->UI.checkBoxColorMatching->setChecked(false);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::setFrameList(std::string frameList)
+{
+  QTE_D();
+
+  d->frameList = frameList;
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::initialState()
+{
+  QTE_D();
+
+  d->args.clear();
+  for (int i = 0; i < this->children().size(); ++i) {
+    if (this->children().at(i)->inherits("QWidget")) {
+      QWidget *child = (QWidget*) this->children().at(i);
+      child->setEnabled(true);
+    }
+  }
+  d->UI.pushButtonStop->setEnabled(false);
+
+  d->UI.doubleSpinBoxDepthMin->setEnabled(false);
+  d->UI.doubleSpinBoxDepthMax->setEnabled(false);
+
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::runningState()
+{
+  QTE_D();
+
+  for (int i = 0; i < this->children().size(); ++i) {
+    if (this->children().at(i)->inherits("QWidget")) {
+      QWidget *child = (QWidget*) this->children().at(i);
+      child->setEnabled(false);
+    }
+  }
+  d->UI.pushButtonStop->setEnabled(true);
+}
+
+//END LaunchPlaneSweepView
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepViewPrivate::addArg(QWidget *item, std::string value)
+{
+  std::string arg = item->property("configField").toString().toStdString();
+
+  if(!value.empty())
+  {
+    arg += "=" + value;
+  }
+  args << QString::fromStdString(arg);
+
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepViewPrivate::addArg(QWidget *item, double value)
+{
+  std::ostringstream sstream;
+  sstream << value;
+  std::string valueStr = sstream.str();
+
+  addArg(item,valueStr);
+}

--- a/gui/LaunchPlaneSweepView.cxx
+++ b/gui/LaunchPlaneSweepView.cxx
@@ -42,6 +42,7 @@
 #include <string>
 #include <QProcess>
 #include <QByteArray>
+#include <QFileDialog>
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -110,13 +111,16 @@ LaunchPlaneSweepView::LaunchPlaneSweepView(QWidget* parent, Qt::WindowFlags flag
   d->psl = new QProcess();
 
   connect(d->psl, SIGNAL(readyRead()),
-         d->dialog, SLOT(ouputPSL()));
+         d->dialog, SLOT(ouputProcess()));
 
   connect(d->psl, SIGNAL(finished(int)),
          this, SLOT(initialState()));
 
   connect(d->UI.pushButtonStop, SIGNAL(clicked(bool)),
          d->psl, SLOT(kill()));
+
+  connect(d->UI.pushButtonExplore, SIGNAL(clicked(bool)),
+         this, SLOT(openFileExplorer()));
 }
 
 //-----------------------------------------------------------------------------
@@ -167,7 +171,7 @@ void LaunchPlaneSweepView::compute()
   imageListFile = "--imageListFile=" + d->frameList;
 
   frameList >> framePath;
-  frameFolder = framePath.substr(0,framePath.find_last_of("/"));
+  frameFolder = framePath.substr(0,framePath.find_last_of("/\\"));
 
   frameList.close();
 
@@ -263,12 +267,24 @@ void LaunchPlaneSweepView::initialState()
 }
 
 //-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::openFileExplorer()
+{
+  QTE_D();
+  QString path = QFileDialog::getOpenFileName();
+
+  d->UI.lineEditPSLPath->setText(path);
+
+}
+
+//-----------------------------------------------------------------------------
 void LaunchPlaneSweepView::runningState()
 {
   QTE_D();
 
-  for (int i = 0; i < this->children().size(); ++i) {
-    if (this->children().at(i)->inherits("QWidget")) {
+  for (int i = 0; i < this->children().size(); ++i)
+  {
+    if (this->children().at(i)->inherits("QWidget"))
+    {
       QWidget *child = (QWidget*) this->children().at(i);
       child->setEnabled(false);
     }

--- a/gui/LaunchPlaneSweepView.cxx
+++ b/gui/LaunchPlaneSweepView.cxx
@@ -60,12 +60,12 @@ public:
 
   QProcess *psl;
 
-  std::string krtdFolder;
-  std::string framesFolder;
-  std::string frameList;
-  std::string landmarksFile;
+  QString krtdFolder;
+  QString framesFolder;
+  QString frameList;
+  QString landmarksFile;
 
-  void addArg(QWidget* item, std::string value="");
+  void addArg(QWidget* item, QString value="");
   void addArg(QWidget *item, double value);
 
   OutputDialog* dialog;
@@ -131,7 +131,7 @@ LaunchPlaneSweepView::~LaunchPlaneSweepView()
 }
 
 //-----------------------------------------------------------------------------
-void LaunchPlaneSweepView::setKrtdFolder(std::string krtdFolder)
+void LaunchPlaneSweepView::setKrtdFolder(QString krtdFolder)
 {
   QTE_D();
 
@@ -139,7 +139,7 @@ void LaunchPlaneSweepView::setKrtdFolder(std::string krtdFolder)
 }
 
 //-----------------------------------------------------------------------------
-void LaunchPlaneSweepView::setFramesFolder(std::string framesFolder)
+void LaunchPlaneSweepView::setFramesFolder(QString framesFolder)
 {
   QTE_D();
 
@@ -147,7 +147,7 @@ void LaunchPlaneSweepView::setFramesFolder(std::string framesFolder)
 }
 
 //-----------------------------------------------------------------------------
-void LaunchPlaneSweepView::setLandmarksFile(std::string landmarksFile)
+void LaunchPlaneSweepView::setLandmarksFile(QString landmarksFile)
 {
   QTE_D();
 
@@ -165,10 +165,10 @@ void LaunchPlaneSweepView::compute()
 
   //Getting frame folder
 
-  std::ifstream frameList(d->frameList);
+  std::ifstream frameList(d->frameList.toStdString());
   std::string framePath, frameFolder, imageListFile;
 
-  imageListFile = "--imageListFile=" + d->frameList;
+  imageListFile = "--imageListFile=" + d->frameList.toStdString();
 
   frameList >> framePath;
   frameFolder = framePath.substr(0,framePath.find_last_of("/\\"));
@@ -178,9 +178,9 @@ void LaunchPlaneSweepView::compute()
   frameFolder = "--frameFolder=" + frameFolder;
 
   d->args <<  QString::fromStdString(frameFolder) ;
-  d->args << QString::fromStdString(d->krtdFolder);
+  d->args << d->krtdFolder;
   d->args << QString::fromStdString(imageListFile);
-  d->args << QString::fromStdString(d->landmarksFile);
+  d->args << d->landmarksFile;
 
   //Parsing arguments from form
 
@@ -199,7 +199,7 @@ void LaunchPlaneSweepView::compute()
     {
       QComboBox *child = qobject_cast<QComboBox*>(this->children().at(i));
 
-      d->addArg(child, child->currentText().toStdString());
+      d->addArg(child, child->currentText());
     }
     else if (this->children().at(i)->inherits("QSpinBox"))
     {
@@ -209,8 +209,7 @@ void LaunchPlaneSweepView::compute()
     }
   }
 
-  d->addArg(d->UI.lineEditOutputDirectory,
-            d->UI.lineEditOutputDirectory->text().toStdString());
+  d->addArg(d->UI.lineEditOutputDirectory, d->UI.lineEditOutputDirectory->text());
 
 
   d->dialog->show();
@@ -241,7 +240,7 @@ void LaunchPlaneSweepView::enableColorMatching()
 }
 
 //-----------------------------------------------------------------------------
-void LaunchPlaneSweepView::setFrameList(std::string frameList)
+void LaunchPlaneSweepView::setFrameList(QString frameList)
 {
   QTE_D();
 
@@ -296,15 +295,15 @@ void LaunchPlaneSweepView::runningState()
 //END LaunchPlaneSweepView
 
 //-----------------------------------------------------------------------------
-void LaunchPlaneSweepViewPrivate::addArg(QWidget *item, std::string value)
+void LaunchPlaneSweepViewPrivate::addArg(QWidget *item, QString value)
 {
-  std::string arg = item->property("configField").toString().toStdString();
+  QString arg = item->property("configField").toString();
 
-  if(!value.empty())
+  if(!value.isEmpty())
   {
-    arg += "=" + value;
+    arg = arg + "=" + value;
   }
-  args << QString::fromStdString(arg);
+  args << arg;
 
 }
 
@@ -315,5 +314,5 @@ void LaunchPlaneSweepViewPrivate::addArg(QWidget *item, double value)
   sstream << value;
   std::string valueStr = sstream.str();
 
-  addArg(item,valueStr);
+  addArg(item,QString::fromStdString(valueStr));
 }

--- a/gui/LaunchPlaneSweepView.cxx
+++ b/gui/LaunchPlaneSweepView.cxx
@@ -121,6 +121,8 @@ LaunchPlaneSweepView::LaunchPlaneSweepView(QWidget* parent, Qt::WindowFlags flag
 
   connect(d->UI.pushButtonExplore, SIGNAL(clicked(bool)),
          this, SLOT(openFileExplorer()));
+
+  initializeComboBoxes();
 }
 
 //-----------------------------------------------------------------------------
@@ -191,7 +193,7 @@ void LaunchPlaneSweepView::compute()
     {
       QComboBox *child = qobject_cast<QComboBox*>(this->children().at(i));
 
-      d->addArg(child, child->currentText());
+      d->addArg(child, child->itemData(child->currentIndex()).toString());
     }
     else if (this->children().at(i)->inherits("QSpinBox"))
     {
@@ -302,6 +304,25 @@ void LaunchPlaneSweepView::runningState()
     }
   }
   d->UI.pushButtonStop->setEnabled(true);
+}
+
+//-----------------------------------------------------------------------------
+void LaunchPlaneSweepView::initializeComboBoxes()
+{
+  QTE_D();
+
+  d->UI.comboBoxMatchCost->addItem("SAD",QVariant("SAD"));
+  d->UI.comboBoxMatchCost->addItem("ZNCC",QVariant("ZNCC"));
+
+  d->UI.comboBoxOcclusionMode->addItem("None",QVariant("None"));
+  d->UI.comboBoxOcclusionMode->addItem("Ref Split",QVariant("RefSplit"));
+  d->UI.comboBoxOcclusionMode->addItem("Best K",QVariant("BestK"));
+
+  d->UI.comboBoxOutputs->addItem("VTI files only",QVariant("vti"));
+  d->UI.comboBoxOutputs->addItem("VTI and VTS",QVariant("vts"));
+  d->UI.comboBoxOutputs->addItem("VTI and VTP",QVariant("vtp"));
+  d->UI.comboBoxOutputs->addItem("VTI, VTP and VTS files",QVariant("vtpvts"));
+  d->UI.comboBoxOutputs->addItem("VTI and VRML files",QVariant("vrml"));
 }
 
 //END LaunchPlaneSweepView

--- a/gui/LaunchPlaneSweepView.h
+++ b/gui/LaunchPlaneSweepView.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2015 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -12,9 +12,9 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- *  * Neither the name Kitware, Inc. nor the names of any contributors may be
- *    used to endorse or promote products derived from this software without
- *    specific prior written permission.
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -28,63 +28,45 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MAPTK_MAINWINDOW_H_
-#define MAPTK_MAINWINDOW_H_
+#ifndef MAPTK_LAUNCHPLANESWEEPVIEW_H_
+#define MAPTK_LAUNCHPLANESWEEPVIEW_H_
 
 #include <qtGlobal.h>
 
 #include <QMainWindow>
 
-class MainWindowPrivate;
+#include <Eigen/SparseCore>
 
-class MainWindow : public QMainWindow
+class LaunchPlaneSweepViewPrivate;
+
+class LaunchPlaneSweepView : public QWidget
 {
   Q_OBJECT
 
 public:
-  explicit MainWindow(QWidget* parent = 0, Qt::WindowFlags flags = 0);
-  virtual ~MainWindow();
+  explicit LaunchPlaneSweepView(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  virtual ~LaunchPlaneSweepView();
+
+  void setKrtdFolder(std::string krtdFolder);
+  void setFramesFolder(std::string framesFolder);
+  void setLandmarksFile(std::string landmarksFile);
+  void setFrameList(std::string frameList);
+
+  void runningState();
 
 public slots:
-  void openFile();
-  void openFile(QString const& path);
-  void openFiles(QStringList const& paths);
+  void compute();
+  void enableColorMatching();
+  void initialState();
 
-  void loadProject(QString const& path);
-  void loadImage(QString const& path);
-  void loadCamera(QString const& path);
-  void loadTracks(QString const& path);
-  void loadLandmarks(QString const& path);
-
-  void saveCameras();
-  void saveCameras(QString const& path);
-  void saveLandmarks();
-  void saveLandmarks(QString const& path);
-
-  void setActiveCamera(int);
-
-  void setViewBackroundColor();
-
-  void showMatchMatrix();
-
-  void showComputeDepthmaps();
-
-  void showAboutDialog();
-  void showUserManual();
 
 protected slots:
-  void setSlideDelay(int);
-  void setSlideshowPlaying(bool);
-  void nextSlide();
-
-  void executeTool(QObject*);
-  void acceptToolResults();
 
 private:
-  QTE_DECLARE_PRIVATE_RPTR(MainWindow)
-  QTE_DECLARE_PRIVATE(MainWindow)
+  QTE_DECLARE_PRIVATE_RPTR(LaunchPlaneSweepView)
+  QTE_DECLARE_PRIVATE(LaunchPlaneSweepView)
 
-  QTE_DISABLE_COPY(MainWindow)
+  QTE_DISABLE_COPY(LaunchPlaneSweepView)
 };
 
 #endif

--- a/gui/LaunchPlaneSweepView.h
+++ b/gui/LaunchPlaneSweepView.h
@@ -47,10 +47,10 @@ public:
   explicit LaunchPlaneSweepView(QWidget* parent = 0, Qt::WindowFlags flags = 0);
   virtual ~LaunchPlaneSweepView();
 
-  void setKrtdFolder(std::string krtdFolder);
-  void setFramesFolder(std::string framesFolder);
-  void setLandmarksFile(std::string landmarksFile);
-  void setFrameList(std::string frameList);
+  void setKrtdFolder(QString krtdFolder);
+  void setFramesFolder(QString framesFolder);
+  void setLandmarksFile(QString landmarksFile);
+  void setFrameList(QString frameList);
 
   void runningState();
 

--- a/gui/LaunchPlaneSweepView.h
+++ b/gui/LaunchPlaneSweepView.h
@@ -48,10 +48,12 @@ public:
   virtual ~LaunchPlaneSweepView();
 
   void setKrtdFolder(QString krtdFolder);
-  void setFramesFolder(QString framesFolder);
   void setLandmarksFile(QString landmarksFile);
   void setFrameList(QString frameList);
+  void setNumCam(int numCam);
 
+  void initalizeValues(QString krtdFolder,QString landmarksFile,
+                       QString frameList,int numCam);
   void runningState();
 
 public slots:

--- a/gui/LaunchPlaneSweepView.h
+++ b/gui/LaunchPlaneSweepView.h
@@ -58,6 +58,7 @@ public slots:
   void compute();
   void enableColorMatching();
   void initialState();
+  void openFileExplorer();
 
 
 protected slots:

--- a/gui/LaunchPlaneSweepView.h
+++ b/gui/LaunchPlaneSweepView.h
@@ -56,6 +56,7 @@ public:
                        QString frameList,int numCam);
   void runningState();
 
+
 public slots:
   void compute();
   void enableColorMatching();
@@ -64,6 +65,7 @@ public slots:
 
 
 protected slots:
+  void initializeComboBoxes();
 
 private:
   QTE_DECLARE_PRIVATE_RPTR(LaunchPlaneSweepView)

--- a/gui/LaunchPlaneSweepView.ui
+++ b/gui/LaunchPlaneSweepView.ui
@@ -47,7 +47,7 @@
       <bool>false</bool>
      </property>
      <property name="decimals">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="minimum">
       <double>0.000000000000000</double>

--- a/gui/LaunchPlaneSweepView.ui
+++ b/gui/LaunchPlaneSweepView.ui
@@ -1,0 +1,437 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LaunchPlaneSweepView</class>
+ <widget class="QWidget" name="LaunchPlaneSweepView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>427</width>
+    <height>775</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Compute Depthmaps with PSL</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Min. Angle Degree Between Frames</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QComboBox" name="comboBoxMatchCost">
+     <property name="configField" stdset="0">
+      <string>--PS_MATCHING_COSTS</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>SAD</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>ZNCC</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Outputs parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Matching Cost Parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="text">
+      <string>Reference Frame Step</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="QSpinBox" name="spinBoxFrameSample">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>20</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MAX_NUM_IMAGES</string>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="1">
+    <widget class="QCheckBox" name="checkBoxUseSubPixel">
+     <property name="text">
+      <string>Use Sub Pixel Computation</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_USE_SUBPIXEL</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1">
+    <widget class="QComboBox" name="comboBoxOutputs">
+     <property name="configField" stdset="0">
+      <string>--writePointClouds</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>vti</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>vtp</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>vts</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>vtpvts</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>vrml</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Depth Max</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Number of Planes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxDepthMin">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>0</number>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MIN_DEPTH</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Matching Window Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxRescaleFactor">
+     <property name="minimum">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.250000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_RESCALE_FACTOR</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxDepthMax">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MAX_DEPTH</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0">
+    <widget class="QLabel" name="label_14">
+     <property name="text">
+      <string>Outputs</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Rescale Factor</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Occlusion Mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lineEditPSLPath">
+     <property name="text">
+      <string>/home/louis/develop/PlaneSweepLib/build/bin/cudaPlanesweepMAPTk</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_15">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Frames Parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <widget class="QSpinBox" name="spinBoxRefFrameStep">
+     <property name="cursor">
+      <cursorShape>ArrowCursor</cursorShape>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>5</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--ref_view_step</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxMinAngle">
+     <property name="minimum">
+      <double>2.000000000000000</double>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MIN_ANGLE_DEGREE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Depth Min</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>Number of Frame to Use</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QCheckBox" name="checkBoxColorMatching">
+     <property name="text">
+      <string>Use Color matching</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_COLOR_MATCHING</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Matching Costs Algorithm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="checkBoxDepthAuto">
+     <property name="text">
+      <string>Depth Auto</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="configFiled" stdset="0">
+      <string/>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_AUTO_RANGE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QComboBox" name="comboBoxOcclusionMode">
+     <property name="configField" stdset="0">
+      <string>--PS_OCCLUSION_MODE</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>None</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>RefSplit</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>BestK</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="17" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Misc. parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QSpinBox" name="spinBoxWindowSize">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>5</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MATCHING_WINDOW_SIZE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="text">
+      <string>PlaneSweepLib path</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="1">
+    <widget class="QSpinBox" name="spinBoxPlanes">
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="value">
+      <number>512</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_NUM_PLANES</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1">
+    <widget class="QLineEdit" name="lineEditOutputDirectory">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>depthmaps</string>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--outputDirectory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Output Directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Depth Parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="0">
+    <widget class="QPushButton" name="pushButtonCompute">
+     <property name="text">
+      <string>Compute</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="1">
+    <widget class="QPushButton" name="pushButtonStop">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Stop</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/gui/LaunchPlaneSweepView.ui
+++ b/gui/LaunchPlaneSweepView.ui
@@ -89,21 +89,6 @@
      <property name="configField" stdset="0">
       <string>--PS_OCCLUSION_MODE</string>
      </property>
-     <item>
-      <property name="text">
-       <string>None</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>RefSplit</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>BestK</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="12" column="0">
@@ -231,31 +216,6 @@
      <property name="configField" stdset="0">
       <string>--writePointClouds</string>
      </property>
-     <item>
-      <property name="text">
-       <string>vti</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>vtp</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>vts</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>vtpvts</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>vrml</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="16" column="0">
@@ -299,16 +259,6 @@
      <property name="configField" stdset="0">
       <string>--PS_MATCHING_COSTS</string>
      </property>
-     <item>
-      <property name="text">
-       <string>SAD</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>ZNCC</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="5" column="1">

--- a/gui/LaunchPlaneSweepView.ui
+++ b/gui/LaunchPlaneSweepView.ui
@@ -6,40 +6,30 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>427</width>
-    <height>775</height>
+    <width>518</width>
+    <height>691</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Compute Depthmaps with PSL</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_11">
+   <item row="20" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Min. Angle Degree Between Frames</string>
+      <string>Rescale Factor</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QComboBox" name="comboBoxMatchCost">
-     <property name="configField" stdset="0">
-      <string>--PS_MATCHING_COSTS</string>
+   <item row="17" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Output Directory</string>
      </property>
-     <item>
-      <property name="text">
-       <string>SAD</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>ZNCC</string>
-      </property>
-     </item>
     </widget>
    </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_16">
+   <item row="18" column="0">
+    <widget class="QLabel" name="label_17">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -47,11 +37,27 @@
       </font>
      </property>
      <property name="text">
-      <string>Outputs parameters</string>
+      <string>Misc. parameters</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxDepthMin">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>0</number>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MIN_DEPTH</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <widget class="QLabel" name="label_4">
      <property name="font">
       <font>
@@ -64,27 +70,57 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_13">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_18">
      <property name="text">
-      <string>Reference Frame Step</string>
+      <string>PlaneSweepLib path</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
-    <widget class="QSpinBox" name="spinBoxFrameSample">
-     <property name="minimum">
-      <number>1</number>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Depth Min</string>
      </property>
-     <property name="value">
-      <number>20</number>
-     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QComboBox" name="comboBoxOcclusionMode">
      <property name="configField" stdset="0">
-      <string>--PS_MAX_NUM_IMAGES</string>
+      <string>--PS_OCCLUSION_MODE</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>None</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>RefSplit</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>BestK</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>Number of Frame to Use</string>
      </property>
     </widget>
    </item>
-   <item row="20" column="1">
+   <item row="23" column="0">
+    <widget class="QPushButton" name="pushButtonCompute">
+     <property name="text">
+      <string>Compute</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="1">
     <widget class="QCheckBox" name="checkBoxUseSubPixel">
      <property name="text">
       <string>Use Sub Pixel Computation</string>
@@ -97,7 +133,100 @@
      </property>
     </widget>
    </item>
-   <item row="15" column="1">
+   <item row="0" column="2">
+    <widget class="QPushButton" name="pushButtonExplore">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Matching Window Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Depth Max</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Occlusion Mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QSpinBox" name="spinBoxRefFrameStep">
+     <property name="cursor">
+      <cursorShape>ArrowCursor</cursorShape>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>5</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--ref_view_step</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Number of Planes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QSpinBox" name="spinBoxWindowSize">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>5</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MATCHING_WINDOW_SIZE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="checkBoxDepthAuto">
+     <property name="text">
+      <string>Depth Auto</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="configFiled" stdset="0">
+      <string/>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_AUTO_RANGE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="1">
+    <widget class="QSpinBox" name="spinBoxPlanes">
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="value">
+      <number>512</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_NUM_PLANES</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1">
     <widget class="QComboBox" name="comboBoxOutputs">
      <property name="configField" stdset="0">
       <string>--writePointClouds</string>
@@ -129,44 +258,14 @@
      </item>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="16" column="0">
+    <widget class="QLabel" name="label_14">
      <property name="text">
-      <string>Depth Max</string>
+      <string>Outputs</string>
      </property>
     </widget>
    </item>
-   <item row="18" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Number of Planes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QDoubleSpinBox" name="doubleSpinBoxDepthMin">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>0</number>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--PS_MIN_DEPTH</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Matching Window Size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="1">
+   <item row="20" column="1">
     <widget class="QDoubleSpinBox" name="doubleSpinBoxRescaleFactor">
      <property name="minimum">
       <double>0.100000000000000</double>
@@ -182,45 +281,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QDoubleSpinBox" name="doubleSpinBoxDepthMax">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--PS_MAX_DEPTH</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QLabel" name="label_14">
-     <property name="text">
-      <string>Outputs</string>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Rescale Factor</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Occlusion Mode</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="lineEditPSLPath">
-     <property name="text">
-      <string>/home/louis/develop/PlaneSweepLib/build/bin/cudaPlanesweepMAPTk</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="label_15">
      <property name="font">
       <font>
@@ -233,171 +294,47 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
-    <widget class="QSpinBox" name="spinBoxRefFrameStep">
-     <property name="cursor">
-      <cursorShape>ArrowCursor</cursorShape>
-     </property>
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="value">
-      <number>5</number>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--ref_view_step</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1">
-    <widget class="QDoubleSpinBox" name="doubleSpinBoxMinAngle">
-     <property name="minimum">
-      <double>2.000000000000000</double>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--PS_MIN_ANGLE_DEGREE</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Depth Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="text">
-      <string>Number of Frame to Use</string>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="1">
-    <widget class="QCheckBox" name="checkBoxColorMatching">
-     <property name="text">
-      <string>Use Color matching</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
+    <widget class="QComboBox" name="comboBoxMatchCost">
      <property name="configField" stdset="0">
-      <string>--PS_COLOR_MATCHING</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Matching Costs Algorithm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QCheckBox" name="checkBoxDepthAuto">
-     <property name="text">
-      <string>Depth Auto</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="configFiled" stdset="0">
-      <string/>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--PS_AUTO_RANGE</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QComboBox" name="comboBoxOcclusionMode">
-     <property name="configField" stdset="0">
-      <string>--PS_OCCLUSION_MODE</string>
+      <string>--PS_MATCHING_COSTS</string>
      </property>
      <item>
       <property name="text">
-       <string>None</string>
+       <string>SAD</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>RefSplit</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>BestK</string>
+       <string>ZNCC</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="17" column="0">
-    <widget class="QLabel" name="label_17">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Misc. parameters</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QSpinBox" name="spinBoxWindowSize">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="value">
-      <number>5</number>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--PS_MATCHING_WINDOW_SIZE</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_18">
-     <property name="text">
-      <string>PlaneSweepLib path</string>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="1">
-    <widget class="QSpinBox" name="spinBoxPlanes">
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-     <property name="value">
-      <number>512</number>
-     </property>
-     <property name="configField" stdset="0">
-      <string>--PS_NUM_PLANES</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="1">
-    <widget class="QLineEdit" name="lineEditOutputDirectory">
+   <item row="5" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxDepthMax">
      <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>depthmaps</string>
+      <bool>false</bool>
      </property>
      <property name="configField" stdset="0">
-      <string>--outputDirectory</string>
+      <string>--PS_MAX_DEPTH</string>
      </property>
     </widget>
    </item>
-   <item row="16" column="0">
-    <widget class="QLabel" name="label">
+   <item row="23" column="1">
+    <widget class="QPushButton" name="pushButtonStop">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
-      <string>Output Directory</string>
+      <string>Stop</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_9">
      <property name="font">
       <font>
@@ -410,23 +347,93 @@
      </property>
     </widget>
    </item>
-   <item row="21" column="0">
-    <widget class="QPushButton" name="pushButtonCompute">
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Compute</string>
+      <string>Matching Costs Algorithm</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="1">
-    <widget class="QPushButton" name="pushButtonStop">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lineEditPSLPath">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="1">
+    <widget class="QLineEdit" name="lineEditOutputDirectory">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="text">
-      <string>Stop</string>
+      <string>depthmaps</string>
      </property>
-     <property name="flat">
-      <bool>false</bool>
+     <property name="configField" stdset="0">
+      <string>--outputDirectory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QCheckBox" name="checkBoxColorMatching">
+     <property name="text">
+      <string>Use Color matching</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_COLOR_MATCHING</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Outputs parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <widget class="QSpinBox" name="spinBoxFrameSample">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>20</number>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MAX_NUM_IMAGES</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxMinAngle">
+     <property name="minimum">
+      <double>2.000000000000000</double>
+     </property>
+     <property name="configField" stdset="0">
+      <string>--PS_MIN_ANGLE_DEGREE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="text">
+      <string>Reference Frame Step</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Min. Angle Degree Between Frames</string>
      </property>
     </widget>
    </item>

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1129,9 +1129,9 @@ void MainWindow::showComputeDepthmaps()
 
   auto window = new LaunchPlaneSweepView();
 
-  window->setKrtdFolder(d->krtdFolder.toStdString());
-  window->setFrameList(d->framesFolder.toStdString());
-  window->setLandmarksFile(d->landmarksFile.toStdString());
+  window->setKrtdFolder(d->krtdFolder);
+  window->setFrameList(d->framesFolder);
+  window->setLandmarksFile(d->landmarksFile);
 
   window->show();
 }

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1129,10 +1129,12 @@ void MainWindow::showComputeDepthmaps()
 
   auto window = new LaunchPlaneSweepView();
 
-  window->setKrtdFolder(d->krtdFolder);
-  window->setFrameList(d->framesFolder);
-  window->setLandmarksFile(d->landmarksFile);
+//  window->setKrtdFolder(d->krtdFolder);
+//  window->setFrameList(d->framesFolder);
+//  window->setLandmarksFile(d->landmarksFile);
 
+  window->initalizeValues(d->krtdFolder, d->landmarksFile,
+                          d->framesFolder, d->cameras.size());
   window->show();
 }
 

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -777,6 +777,7 @@ void MainWindow::loadProject(QString const& path)
   d->krtdFolder = project.cameraPath;
   d->landmarksFile = project.landmarks;
   d->framesFolder = project.frameListPath;
+  d->UI.menuDepthmaps->setEnabled(true);
 
   d->UI.worldView->resetView();
 }

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -41,6 +41,7 @@
 #include "MatchMatrixWindow.h"
 #include "Project.h"
 #include "vtkMaptkCamera.h"
+#include "LaunchPlaneSweepView.h"
 
 #include <maptk/match_matrix.h>
 #include <maptk/version.h>
@@ -266,6 +267,10 @@ public:
 
   QQueue<int> orphanImages;
   QQueue<int> orphanCameras;
+
+  QString krtdFolder;
+  QString landmarksFile;
+  QString framesFolder;
 };
 
 QTE_IMPLEMENT_D_FUNC(MainWindow)
@@ -628,6 +633,9 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   connect(d->UI.camera, SIGNAL(valueChanged(int)),
           this, SLOT(setActiveCamera(int)));
 
+  connect(d->UI.actionPlaneSweepLib, SIGNAL(triggered(bool)),
+          this, SLOT(showComputeDepthmaps()));
+
   this->setSlideDelay(d->UI.slideDelay->value());
 
   // Set up UI persistence and restore previous state
@@ -765,6 +773,10 @@ void MainWindow::loadProject(QString const& path)
       }
     }
   }
+
+  d->krtdFolder = project.cameraPath;
+  d->landmarksFile = project.landmarks;
+  d->framesFolder = project.frameListPath;
 
   d->UI.worldView->resetView();
 }
@@ -1109,6 +1121,19 @@ void MainWindow::showMatchMatrix()
     window->setMatrix(mm);
     window->show();
   }
+}
+
+void MainWindow::showComputeDepthmaps()
+{
+  QTE_D();
+
+  auto window = new LaunchPlaneSweepView();
+
+  window->setKrtdFolder(d->krtdFolder.toStdString());
+  window->setFrameList(d->framesFolder.toStdString());
+  window->setLandmarksFile(d->landmarksFile.toStdString());
+
+  window->show();
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>27</height>
     </rect>
    </property>
    <widget class="qtMenu" name="menuFile">
@@ -63,6 +63,9 @@
      <string>&amp;Compute</string>
     </property>
     <widget class="QMenu" name="menuDepthmaps">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="title">
       <string>Depthmaps...</string>
      </property>
@@ -282,6 +285,9 @@
    </property>
   </action>
   <action name="actionPlaneSweepLib">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Plane Sweep Lib</string>
    </property>
@@ -303,7 +309,7 @@
   <customwidget>
    <class>qtMenu</class>
    <extends>QMenu</extends>
-   <header>qtMenu.h</header>
+   <header location="global">qtMenu.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -62,6 +62,13 @@
     <property name="title">
      <string>&amp;Compute</string>
     </property>
+    <widget class="QMenu" name="menuDepthmaps">
+     <property name="title">
+      <string>Depthmaps...</string>
+     </property>
+     <addaction name="actionPlaneSweepLib"/>
+    </widget>
+    <addaction name="menuDepthmaps"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuCompute"/>
@@ -274,6 +281,11 @@
     <string>Change the background color of the views</string>
    </property>
   </action>
+  <action name="actionPlaneSweepLib">
+   <property name="text">
+    <string>Plane Sweep Lib</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -291,7 +303,7 @@
   <customwidget>
    <class>qtMenu</class>
    <extends>QMenu</extends>
-   <header location="global">qtMenu.h</header>
+   <header>qtMenu.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/gui/OutputDialog.cxx
+++ b/gui/OutputDialog.cxx
@@ -67,10 +67,9 @@ OutputDialog::OutputDialog(QWidget* parent, Qt::WindowFlags flags)
   QTE_D();
 
   this->setAttribute(Qt::WA_DeleteOnClose);
+
   // Set up UI
   d->UI.setupUi(this);
-
-  // Set up signals/slots
 
 }
 

--- a/gui/OutputDialog.cxx
+++ b/gui/OutputDialog.cxx
@@ -49,7 +49,7 @@ public:
   Ui::OutputDialog UI;
   qtUiState uiState;
 
-  QProcess *psl;
+  QProcess *process;
 };
 
 QTE_IMPLEMENT_D_FUNC(OutputDialog)
@@ -86,14 +86,15 @@ void OutputDialog::setOutputToDisplay(QProcess *process)
 {
   QTE_D();
 
-  d->psl = process;
+  d->process = process;
 }
 
-void OutputDialog::ouputPSL()
+//-----------------------------------------------------------------------------
+void OutputDialog::ouputProcess()
 {
   QTE_D();
 
-    QString outputText(d->psl->readAll());
+    QString outputText(d->process->readAll());
     d->UI.plainTextEdit->appendPlainText(outputText);
 }
 

--- a/gui/OutputDialog.cxx
+++ b/gui/OutputDialog.cxx
@@ -1,0 +1,101 @@
+/*ckwg +29
+ * Copyright 2015 by Kitware, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "OutputDialog.h"
+
+#include "ui_OutputDialog.h"
+
+#include <qtGradient.h>
+#include <qtIndexRange.h>
+#include <qtUiState.h>
+#include <qtUiStateItem.h>
+#include <stdio.h>
+#include <QProcess>
+
+//BEGIN OutputDialogPrivate
+
+//-----------------------------------------------------------------------------
+class OutputDialogPrivate
+{
+public:
+
+  Ui::OutputDialog UI;
+  qtUiState uiState;
+
+  QProcess *psl;
+};
+
+QTE_IMPLEMENT_D_FUNC(OutputDialog)
+
+
+//END OutputDialogPrivate
+
+
+//BEGIN OutputDialog
+
+//-----------------------------------------------------------------------------
+OutputDialog::OutputDialog(QWidget* parent, Qt::WindowFlags flags)
+  : QDialog(parent, flags), d_ptr(new OutputDialogPrivate)
+{
+  QTE_D();
+
+  this->setAttribute(Qt::WA_DeleteOnClose);
+  // Set up UI
+  d->UI.setupUi(this);
+
+  // Set up signals/slots
+
+}
+
+//-----------------------------------------------------------------------------
+OutputDialog::~OutputDialog()
+{
+  QTE_D();
+  d->uiState.save();
+}
+
+//-----------------------------------------------------------------------------
+void OutputDialog::setOutputToDisplay(QProcess *process)
+{
+  QTE_D();
+
+  d->psl = process;
+}
+
+void OutputDialog::ouputPSL()
+{
+  QTE_D();
+
+    QString outputText(d->psl->readAll());
+    d->UI.plainTextEdit->appendPlainText(outputText);
+}
+
+
+//END OutputDialog

--- a/gui/OutputDialog.h
+++ b/gui/OutputDialog.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2015 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -12,9 +12,9 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- *  * Neither the name Kitware, Inc. nor the names of any contributors may be
- *    used to endorse or promote products derived from this software without
- *    specific prior written permission.
+ *  * Neither name of Kitware, Inc. nor the names of any contributors may be used
+ *    to endorse or promote products derived from this software without specific
+ *    prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -28,63 +28,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MAPTK_MAINWINDOW_H_
-#define MAPTK_MAINWINDOW_H_
+#ifndef MAPTK_OUTPUTDIALOG_H_
+#define MAPTK_OUTPUTDIALOG_H_
 
 #include <qtGlobal.h>
+#include <QDialog>
 
 #include <QMainWindow>
 
-class MainWindowPrivate;
 
-class MainWindow : public QMainWindow
+class OutputDialogPrivate;
+
+class QProcess;
+
+class OutputDialog : public QDialog
 {
   Q_OBJECT
 
 public:
-  explicit MainWindow(QWidget* parent = 0, Qt::WindowFlags flags = 0);
-  virtual ~MainWindow();
+  explicit OutputDialog(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  virtual ~OutputDialog();
+  void setOutputToDisplay(QProcess *process);
+
 
 public slots:
-  void openFile();
-  void openFile(QString const& path);
-  void openFiles(QStringList const& paths);
-
-  void loadProject(QString const& path);
-  void loadImage(QString const& path);
-  void loadCamera(QString const& path);
-  void loadTracks(QString const& path);
-  void loadLandmarks(QString const& path);
-
-  void saveCameras();
-  void saveCameras(QString const& path);
-  void saveLandmarks();
-  void saveLandmarks(QString const& path);
-
-  void setActiveCamera(int);
-
-  void setViewBackroundColor();
-
-  void showMatchMatrix();
-
-  void showComputeDepthmaps();
-
-  void showAboutDialog();
-  void showUserManual();
-
-protected slots:
-  void setSlideDelay(int);
-  void setSlideshowPlaying(bool);
-  void nextSlide();
-
-  void executeTool(QObject*);
-  void acceptToolResults();
+  void ouputPSL();
 
 private:
-  QTE_DECLARE_PRIVATE_RPTR(MainWindow)
-  QTE_DECLARE_PRIVATE(MainWindow)
+  QTE_DECLARE_PRIVATE_RPTR(OutputDialog)
+  QTE_DECLARE_PRIVATE(OutputDialog)
 
-  QTE_DISABLE_COPY(MainWindow)
+  QTE_DISABLE_COPY(OutputDialog)
 };
 
 #endif

--- a/gui/OutputDialog.h
+++ b/gui/OutputDialog.h
@@ -52,7 +52,7 @@ public:
 
 
 public slots:
-  void ouputPSL();
+  void ouputProcess();
 
 private:
   QTE_DECLARE_PRIVATE_RPTR(OutputDialog)

--- a/gui/OutputDialog.ui
+++ b/gui/OutputDialog.ui
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OutputDialog</class>
+ <widget class="QDialog" name="OutputDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>508</width>
+    <height>369</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QPlainTextEdit" name="plainTextEdit"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/gui/OutputDialog.ui
+++ b/gui/OutputDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Output Trace</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/gui/Project.cxx
+++ b/gui/Project.cxx
@@ -79,6 +79,7 @@ bool Project::read(QString const& path)
 
     // Read image list
     auto const& iflPath = config->get_value<std::string>("image_list_file");
+    this->frameListPath = QString::fromStdString(iflPath);
     QFile ifl(base.filePath(qtString(iflPath)));
     if (!ifl.open(QIODevice::ReadOnly | QIODevice::Text))
     {

--- a/gui/Project.h
+++ b/gui/Project.h
@@ -38,6 +38,7 @@ struct Project
   bool read(QString const& path);
 
   QStringList images;
+  QString frameListPath;
   QString cameraPath;
 
   QString tracks;


### PR DESCRIPTION
A simple GUI for launching the plane sweep algorithm (depthmaps generation) of PlaneSweepLib directly from the Map-TK's GUI.
How to use:
* Load a project containing cameras and landmarks into mapgui.
* Go to Compute -> Depthmaps... -> Plane Sweep Lib
* Indicate the path to your version of PlaneSweepLib/build/bin/cudaPlanesweepMAPTk
* Compute

You can input any value for the different PSL parameters but the ones by default should work well.