### PR TITLE
Added path to frame display in camera view

### DIFF
--- a/doc/rel_notes/0.9.0.txt
+++ b/doc/rel_notes/0.9.0.txt
@@ -52,5 +52,8 @@ Tools
  * Added an option to display the world axes around the visible geometry.
    This option can be enabled and disabled in the "View" menu.
 
+ * The absolute path to the current frame is now displayed at the bottom of the
+   Camera view.
+
 Fixes since v0.8.0
 -------------------------------

--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -607,6 +607,13 @@ void CameraView::addFeatureTrack(kwiver::vital::track const& track)
   d->updateFeatures(this);
 }
 
+void CameraView::setFrameName(QString frameName)
+{
+  QTE_D();
+
+  d->UI.labelImagePath->setText(frameName);
+}
+
 //-----------------------------------------------------------------------------
 void CameraView::addLandmark(
   kwiver::vital::landmark_id_t id, double x, double y)

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -56,6 +56,8 @@ public:
 
   void addFeatureTrack(kwiver::vital::track const&);
 
+  void setFrameName(QString frameName);
+
 public slots:
   void setBackgroundColor(QColor const&);
 

--- a/gui/CameraView.ui
+++ b/gui/CameraView.ui
@@ -14,7 +14,16 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -28,6 +37,13 @@
      <addaction name="actionShowFeatures"/>
      <addaction name="actionShowLandmarks"/>
      <addaction name="actionShowResiduals"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelImagePath">
+     <property name="text">
+      <string/>
+     </property>
     </widget>
    </item>
    <item>

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -454,6 +454,7 @@ void MainWindowPrivate::updateCameraView()
     return;
   }
 
+  this->UI.cameraView->setFrameName(cd.imagePath);
   // Show landmarks
   this->UI.cameraView->clearLandmarks();
   if (this->landmarks)


### PR DESCRIPTION
It can be useful sometimes to have the full path of the frame displayed in the camera view available.
Maybe this should be an optional display?