### PR TITLE
WebGL export style tweaks

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(qtExtensions REQUIRED)
 include(${qtExtensions_USE_FILE})
 
 find_package(VTK 6.2 REQUIRED)
-
 include(${VTK_USE_FILE})
 
 #
@@ -22,12 +21,6 @@ include_directories(
   ${MAPTK_SOURCE_DIR}
   ${MAPTK_BINARY_DIR}
 )
-
-if(vtkWebGLExporter_LOADED)
-  message(STATUS "Module vtkWebGLExporter loaded, wekGL export enabled")
-  add_definitions(-DVTKWEBGLEXPORTER)
-endif()
-
 
 set(gui_am_ui
   CameraView.ui
@@ -138,7 +131,6 @@ kwiver_add_executable(mapgui
 )
 unset(no_install)
 
-
 target_link_libraries(mapgui
   maptk
   vital_apm
@@ -157,6 +149,8 @@ target_link_libraries(mapgui
 )
 
 if(vtkWebGLExporter_LOADED)
+  message(STATUS "Module vtkWebGLExporter present: wekGL export enabled")
+  target_compile_definitions(mapgui PRIVATE -DVTKWEBGLEXPORTER)
   target_link_libraries(mapgui vtkWebGLExporter)
 endif()
 

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -56,7 +56,6 @@ public:
 
   void addFeatureTrack(kwiver::vital::track const&);
 
-
 public slots:
   void setBackgroundColor(QColor const&);
 

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -637,8 +637,9 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
 #ifdef VTKWEBGLEXPORTER
   d->UI.actionWebGLScene->setVisible(true);
   connect(d->UI.actionWebGLScene, SIGNAL(triggered(bool)),
-          this, SLOT(exportWebGLScene()));
+          this, SLOT(saveWebGLScene()));
 #endif
+
   // Set up UI persistence and restore previous state
   auto const sdItem = new qtUiState::Item<int, QSlider>(
     d->UI.slideDelay, &QSlider::value, &QSlider::setValue);
@@ -979,6 +980,24 @@ void MainWindow::saveCameras(QString const& path)
 }
 
 //-----------------------------------------------------------------------------
+void MainWindow::saveWebGLScene()
+{
+#ifdef VTKWEBGLEXPORTER
+  QTE_D();
+
+  auto const path = QFileDialog::getSaveFileName(
+    this, "Export Scene to WebGL", QString(),
+    "WebGL scene file (*.html);;"
+    "All Files (*)");
+
+  if (!path.isEmpty())
+  {
+    d->UI.worldView->exportWebGLScene(path);
+  }
+#endif
+}
+
+//-----------------------------------------------------------------------------
 void MainWindow::setSlideDelay(int delayExp)
 {
   QTE_D();
@@ -1166,22 +1185,5 @@ void MainWindow::showUserManual()
       "The user manual could not be located. Please check your installation.");
   }
 }
-
-
-#ifdef VTKWEBGLEXPORTER
-//-----------------------------------------------------------------------------
-void MainWindow::exportWebGLScene()
-{
-  QTE_D();
-
-  auto const path = QFileDialog::getSaveFileName(
-    this, "Export Scene to WebGL", QString(),
-    "WebGL scene file (*.html);;"
-    "All Files (*)");
-
-  d->UI.worldView->exportWebGLScene(path);
-
-}
-#endif
 
 //END MainWindow

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -60,6 +60,7 @@ public slots:
   void saveCameras(QString const& path);
   void saveLandmarks();
   void saveLandmarks(QString const& path);
+  void saveWebGLScene();
 
   void setActiveCamera(int);
 
@@ -69,10 +70,6 @@ public slots:
 
   void showAboutDialog();
   void showUserManual();
-
-#ifdef VTKWEBGLEXPORTER
-  void exportWebGLScene();
-#endif
 
 protected slots:
   void setSlideDelay(int);

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -79,9 +79,7 @@ public slots:
   void viewToWorldFront();
   void viewToWorldBack();
 
-#ifdef VTKWEBGLEXPORTER
   void exportWebGLScene(QString const& path);
-#endif
 
   void invalidateGeometry();
 


### PR DESCRIPTION
Rename API's for consistency. Avoid conditional slots (among other things, moc doesn't understand target properties for compile definitions). Fix various minor style issues. Rewrite comment about VTK bug to not make future claims about VTK (the bug isn't fixed in VTK upstream yet, though there is a merge request to fix it; instead, link to the merge request).