### PR TITLE
Fix sba algo and tool

### DIFF
--- a/doc/rel_notes/0.9.0.txt
+++ b/doc/rel_notes/0.9.0.txt
@@ -104,6 +104,8 @@ Tools
    when only a subset of cameras are computed and we do not want a mix of
    old and new camera files.
 
+ * Added ``-h`` option to C++ track features too. Equivalent to ``--help``.
+
 Scripts
 
  * Added a Python script which uses OpenCV to produce mosaicked images of
@@ -135,3 +137,11 @@ Tools
    that filters tracks based on match matrix importance.  The idea is that
    long tracks are usually most important, but some short tracks may be more
    important if they are the only tracks that tie together a pair of frames.
+
+ * Removed call to landmark triangulation algorithm that was effectively doing
+   nothing.
+
+VXL
+
+ * Fixed bug in bundle adjust implementation where input landmarks were being
+   accidentally modified in-place.

--- a/maptk/plugins/vxl/bundle_adjust.cxx
+++ b/maptk/plugins/vxl/bundle_adjust.cxx
@@ -386,7 +386,10 @@ bundle_adjust
     {
       const vgl_point_3d<double>& pt = active_world_pts[i];
       vector_3d loc(pt.x(), pt.y(), pt.z());
-      landmark_sptr lm = lms[lm_id_index[i]];
+      // Cloning here so we don't change the landmarks contained in the input
+      // map.
+      landmark_sptr lm = lms[lm_id_index[i]]->clone();
+      lms[lm_id_index[i]] = lm;
       if( landmark_d* lmd = dynamic_cast<landmark_d*>(lm.get()) )
       {
         lmd->set_loc(loc);

--- a/tools/bundle_adjust_tracks.cxx
+++ b/tools/bundle_adjust_tracks.cxx
@@ -187,11 +187,11 @@ static kwiver::vital::config_block_sptr default_config()
                     "when updating cameras. This option is only relevent if a "
                     "value is give to the input_pos_files option.");
 
-      config->set_value("krtd_clean_up", "false",
-                        "Delete all previously existing KRTD files present in output_krtd_dir before writing new KRTD files.");
+  config->set_value("krtd_clean_up", "false",
+                    "Delete all previously existing KRTD files present in output_krtd_dir before writing new KRTD files.");
 
-      config->set_value("depthmaps_images_file", "",
-                        "An optional file containing paths to depthmaps as image datas.");
+  config->set_value("depthmaps_images_file", "",
+                    "An optional file containing paths to depthmaps as image datas.");
 
   kwiver::vital::algo::bundle_adjust::get_nested_algo_configuration("bundle_adjuster", config,
                                                      kwiver::vital::algo::bundle_adjust_sptr());

--- a/tools/bundle_adjust_tracks.cxx
+++ b/tools/bundle_adjust_tracks.cxx
@@ -814,8 +814,6 @@ static int maptk_main(int argc, char const* argv[])
     {
       cameras[v.first] = v.second->clone();
     }
-    // Triangulate initial landmarks based on cameras and tracks
-    triangulator->triangulate(input_cam_map, tracks, lm_map);
   }
   kwiver::vital::camera_map_sptr cam_map;
   if(!cameras.empty())

--- a/tools/track_features.cxx
+++ b/tools/track_features.cxx
@@ -228,6 +228,7 @@ static int maptk_main(int argc, char const* argv[])
   typedef kwiversys::CommandLineArguments argT;
 
   arg.AddArgument( "--help",        argT::NO_ARGUMENT, &opt_help, "Display usage information" );
+  arg.AddArgument( "-h",            argT::NO_ARGUMENT, &opt_help, "Display usage information" );
   arg.AddArgument( "--config",      argT::SPACE_ARGUMENT, &opt_config, "Configuration file for tool" );
   arg.AddArgument( "-c",            argT::SPACE_ARGUMENT, &opt_config, "Configuration file for tool" );
   arg.AddArgument( "--output-config", argT::SPACE_ARGUMENT, &opt_out_config,


### PR DESCRIPTION
Found that a call to the triangulator algorithm in the bundle adjust tracks tool was effectively doing nothing due to changes made when the initialize-landmarks-tracks algo was introduced.

Fixed bug in VXL implementation if SBA where it was modifying input landmarks in place instead of making new ones.