### PR TITLE
Fix Ceres assertion

### DIFF
--- a/doc/rel_notes/0.9.1.txt
+++ b/doc/rel_notes/0.9.1.txt
@@ -7,3 +7,11 @@ MAP-Tk v0.9.1 is a bug fix release with no new functionality.
 
 Fixes since v0.9.0
 --------------------
+
+Ceres Plugin
+
+ * Fixed an assertion from Ceres that caused program termination due to adding
+   constraints on camera intrinsics that were not used in the optimization.
+   We now keep track of which intrinsics are used and only constrain those.
+   The error message was:
+   "problem_impl.cc:65 Check failed: it != parameter_map.end() Parameter block not found"

--- a/maptk/plugins/ceres/bundle_adjust.cxx
+++ b/maptk/plugins/ceres/bundle_adjust.cxx
@@ -553,6 +553,7 @@ bundle_adjust
   bool loss_func_used = false;
 
   // Add the residuals for each relevant observation
+  std::set<unsigned int> used_intrinsics;
   VITAL_FOREACH(const track_sptr& t, trks)
   {
     const track_id_t id = t->id();
@@ -572,6 +573,7 @@ bundle_adjust
       }
       unsigned intr_idx = frame_to_intr_map[ts->frame_id];
       double * intr_params_ptr = &camera_intr_params[intr_idx][0];
+      used_intrinsics.insert(intr_idx);
       vector_2d pt = ts->feat->loc();
       problem.AddResidualBlock(create_cost_func(d_->lens_distortion_type,
                                                 pt.x(), pt.y()),
@@ -582,8 +584,9 @@ bundle_adjust
       loss_func_used = true;
     }
   }
-  VITAL_FOREACH(std::vector<double>& cip, camera_intr_params)
+  VITAL_FOREACH(const unsigned int idx, used_intrinsics)
   {
+    std::vector<double>& cip = camera_intr_params[idx];
     // apply the constraints
     if (constant_intrinsics.size() > 4 + ndp)
     {


### PR DESCRIPTION
Fixed an assertion from Ceres that caused program termination due to adding constraints on camera intrinsics that were not used in the optimization. We now keep track of which intrinsics are used and only constrain those.  The error message was:

    problem_impl.cc:65 Check failed: it != parameter_map.end() Parameter block not found