### PR TITLE
Inverse the scale ratio for the camera used for the depthmap unprojection

### DIFF
--- a/gui/vtkMaptkImageUnprojectDepth.cxx
+++ b/gui/vtkMaptkImageUnprojectDepth.cxx
@@ -99,8 +99,8 @@ void vtkMaptkImageUnprojectDepth::SimpleExecute(vtkImageData* input,
 
   // Get the scaled camera for doing the unproject
   auto const imageRatio =
-    static_cast<double>(this->Camera->GetImageDimensions()[0]) /
-    static_cast<double>(input->GetDimensions()[0]);
+    static_cast<double>(input->GetDimensions()[0]) /
+    static_cast<double>(this->Camera->GetImageDimensions()[0]);
   auto const scaledCamera = this->Camera->ScaledK(imageRatio);
 
   vtkDataArray* inputPoints = output->GetPointData()->GetArray(


### PR DESCRIPTION
The scale ratio for the depthmap unprojection used here is inversed: it needs to be the ratio of the actual image dimensions by the camera's image dimensions to generate a new camera scaled to the right dimensions.