### PR TITLE
Fixed display of frame numbers in match matrix window status bar

### DIFF
--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1180,7 +1180,7 @@ void MainWindow::showMatchMatrix()
 
     // Show window
     auto window = new MatchMatrixWindow();
-    window->setMatrix(mm);
+    window->setMatrix(mm, frames);
     window->show();
   }
 }

--- a/gui/MatchMatrixWindow.cxx
+++ b/gui/MatchMatrixWindow.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -169,6 +169,7 @@ public:
 
   Eigen::SparseMatrix<uint> matrix;
   uint maxValue;
+  std::vector<kwiver::vital::frame_id_t> frames;
 
   QImage image;
   int offset;
@@ -360,13 +361,16 @@ void MatchMatrixImageItem::updateStatusText(const QPointF& pos)
     return;
   }
 
+  kwiver::vital::frame_id_t fx = q->frames[x];
+  kwiver::vital::frame_id_t fy = q->frames[y];
+
   // Show status text
   if (x == y)
   {
     static auto const format =
       QString("Frame %1 has %2 feature point(s)");
 
-    q->UI.statusBar->showMessage(format.arg(x).arg(q->matrix.coeff(x, y)));
+    q->UI.statusBar->showMessage(format.arg(fx).arg(q->matrix.coeff(x, y)));
   }
   else
   {
@@ -377,7 +381,7 @@ void MatchMatrixImageItem::updateStatusText(const QPointF& pos)
     auto const cy = q->matrix.coeff(y, y);
     auto const cxy = q->matrix.coeff(x, y);
 
-    q->UI.statusBar->showMessage(format.arg(x).arg(y).arg(cx).arg(cy).arg(cxy));
+    q->UI.statusBar->showMessage(format.arg(fx).arg(fy).arg(cx).arg(cy).arg(cxy));
   }
 }
 
@@ -456,12 +460,14 @@ MatchMatrixWindow::~MatchMatrixWindow()
 }
 
 //-----------------------------------------------------------------------------
-void MatchMatrixWindow::setMatrix(Eigen::SparseMatrix<uint> const& matrix)
+void MatchMatrixWindow::setMatrix(Eigen::SparseMatrix<uint> const& matrix,
+                                  std::vector<kwiver::vital::frame_id_t> const& frames)
 {
   QTE_D();
 
   d->matrix = matrix;
   d->maxValue = sparseMax(matrix);
+  d->frames = frames;
 
   this->updateImage();
 }

--- a/gui/MatchMatrixWindow.h
+++ b/gui/MatchMatrixWindow.h
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2016 by Kitware, Inc.
+ * Copyright 2016-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,8 @@
 
 #include <Eigen/SparseCore>
 
+#include <vital/vital_types.h>
+
 class MatchMatrixWindowPrivate;
 
 class MatchMatrixWindow : public QMainWindow
@@ -48,7 +50,8 @@ public:
   virtual ~MatchMatrixWindow();
 
 public slots:
-  void setMatrix(Eigen::SparseMatrix<uint> const&);
+  void setMatrix(Eigen::SparseMatrix<uint> const&,
+                 std::vector<kwiver::vital::frame_id_t> const&);
 
   void saveImage();
   void saveImage(QString const& path);


### PR DESCRIPTION
The matrix indices were being displayed as frame numbers in the Match
Matrix Window status bar.  This was correct if the match matrix
contained every frame starting from zero, the most common case.
However, it was wrong when the video does not start at the beginning or
has skipped frames.  This commit uses the frame number vector to look up
the appropriate frame number for display.