### PR TITLE
Replace fletch_ROOT with fletch_DIR

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -241,14 +241,15 @@ if (MAPTK_FIXUP_BUNDLE_ON_PACKAGE)
   list(APPEND FIXUP_DIRS "${qtExtensions_DIR}/${BINARY_DIR}")
 
   list(APPEND FIXUP_DIRS "${KWIVER_LIBRARY_DIR}/${BINARY_DIR}")
-  if(DEFINED fletch_ROOT)
+  if(DEFINED fletch_DIR)
     if(WIN32)
-	  list(APPEND FIXUP_DIRS "${fletch_ROOT}/bin")
-	  # this is a hack for now.  Fletch should really export paths like this.
-	  list(APPEND FIXUP_DIRS "${fletch_ROOT}/x64/vc12/bin")
-	else()
-	  list(APPEND FIXUP_DIRS "${fletch_ROOT}/lib")
-	endif()
+      list(APPEND FIXUP_DIRS "${fletch_DIR}/bin")
+      # this is a hack for now.  Fletch should really export paths like this.
+      list(APPEND FIXUP_DIRS "${fletch_DIR}/x64/vc14/bin")
+      list(APPEND FIXUP_DIRS "${fletch_DIR}/x64/vc15/bin")
+    else()
+      list(APPEND FIXUP_DIRS "${fletch_DIR}/lib")
+    endif()
   endif()
 
 


### PR DESCRIPTION
fletch_ROOT has been replaced by fletch_DIR in Fletch.  Also update
special Visual Studio fixup paths.