### PR TITLE
Updated to use write_feature_track_file

### DIFF
--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1088,7 +1088,7 @@ void MainWindow::saveTracks(QString const& path)
 
   try
   {
-    kwiver::vital::write_track_file(d->tracks, kvPath(path));
+    kwiver::vital::write_feature_track_file(d->tracks, kvPath(path));
   }
   catch (...)
   {

--- a/tools/bundle_adjust_tracks.cxx
+++ b/tools/bundle_adjust_tracks.cxx
@@ -536,7 +536,7 @@ static int maptk_main(int argc, char const* argv[])
       std::string out_track_file = config->get_value<std::string>("filtered_track_file");
       if( out_track_file != "" )
       {
-        kwiver::vital::write_track_file(tracks, out_track_file);
+        kwiver::vital::write_feature_track_file(tracks, out_track_file);
       }
     }
 

--- a/tools/python/track_features.py
+++ b/tools/python/track_features.py
@@ -228,7 +228,7 @@ def main():
 
     log.info("Writing tracks file: %s", output_tracks_fp)
     safe_create_dir(os.path.dirname(output_tracks_fp))
-    track_set.write_tracks_file(output_tracks_fp)
+    track_set.write_feature_tracks_file(output_tracks_fp)
 
 
 if __name__ == '__main__':

--- a/tools/track_features.cxx
+++ b/tools/track_features.cxx
@@ -473,7 +473,7 @@ static int maptk_main(int argc, char const* argv[])
   }
 
   // Writing out tracks to file
-  kwiver::vital::write_track_file(tracks, output_tracks_file);
+  kwiver::vital::write_feature_track_file(tracks, output_tracks_file);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This change was missed in the previous update to use new feature tracks
from KWIVER.  The use of write_track_file still compiled, but only wrote
out the base track information, which was not correct.

Resolves #259 