### PR TITLE
Update installation and search paths for kwiver plugins

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -284,17 +284,17 @@ if (MAPTK_FIXUP_BUNDLE_ON_PACKAGE)
   list(APPEND FIXUP_DIRS "${QT_LIBRARY_DIR}")
   list(APPEND FIXUP_DIRS "${QT_BINARY_DIR}")
 
-  install(DIRECTORY "${KWIVER_DIR}/lib/${BINARY_DIR}/modules" DESTINATION lib
+  install(DIRECTORY "${KWIVER_DIR}/lib/${BINARY_DIR}/kwiver/modules" DESTINATION lib
           COMPONENT Runtime
           FILES_MATCHING PATTERN "*plugin${CMAKE_SHARED_MODULE_SUFFIX}" )
 
-  install(DIRECTORY "${KWIVER_DIR}/lib/${BINARY_DIR}/modules/"
+  install(DIRECTORY "${KWIVER_DIR}/lib/${BINARY_DIR}/kwiver/modules/"
           DESTINATION ${plugin_dest_dir}
           COMPONENT Runtime
           FILES_MATCHING PATTERN "*logger${CMAKE_SHARED_MODULE_SUFFIX}"
           PATTERN "plugin_explorer" EXCLUDE )
 
-  install(DIRECTORY "${KWIVER_DIR}/lib/${BINARY_DIR}/sprokit" DESTINATION lib
+  install(DIRECTORY "${KWIVER_DIR}/lib/${BINARY_DIR}/kwiver/processes" DESTINATION lib
           COMPONENT Runtime
           FILES_MATCHING PATTERN "*${CMAKE_SHARED_MODULE_SUFFIX}" )
 

--- a/gui/main.cxx
+++ b/gui/main.cxx
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
   auto const rel_path = stdString(exeDir.absoluteFilePath(".."));
   auto & vpm = kwiver::vital::plugin_manager::instance();
   vpm.add_search_path(rel_path + "/lib/modules");
-  vpm.add_search_path(rel_path + "/lib/sprokit");
+  vpm.add_search_path(rel_path + "/lib/processes");
   vpm.load_all_plugins();
 
   // Tell PROJ where to find its data files


### PR DESCRIPTION
These path changes are required to match changes that have happened in KWIVER.