### PR TITLE
Overwrite the LOG4CPLUS_CONFIGURATION with a MAP-Tk specific version

### DIFF
--- a/CMake/setup_MAPTK.build.bat.in
+++ b/CMake/setup_MAPTK.build.bat.in
@@ -4,7 +4,7 @@
 if [%1] == [] (
   set config=@CMAKE_BUILD_TYPE@
 ) else (
-  set config=%1 
+  set config=%1
 )
 
 cd @KWIVER_DIR@
@@ -12,3 +12,4 @@ call setup_KWIVER.bat %config%
 cd @MAPTK_BINARY_DIR@
 set PATH=%PATH%;@MAPTK_BINARY_DIR@/bin/%config%;
 set KWIVER_CONFIG_PATH=%KWIVER_CONFIG_PATH%;@MAPTK_BINARY_DIR@\share\maptk\@MAPTK_VERSION@\config
+set LOG4CPLUS_CONFIGURATION=@MAPTK_BINARY_DIR@\share\maptk\@MAPTK_VERSION@\config\log4cplus.properties

--- a/CMake/setup_MAPTK.build.sh.in
+++ b/CMake/setup_MAPTK.build.sh.in
@@ -10,3 +10,5 @@ cd @KWIVER_DIR@
 source setup_KWIVER.sh
 cd @MAPTK_BINARY_DIR@
 
+export LOG4CPLUS_CONFIGURATION=@MAPTK_BINARY_DIR@/share/maptk/@MAPTK_VERSION@/config/log4cplus.properties
+


### PR DESCRIPTION
This change requires Kitware/kwiver#741 to work in the MSVC environment

@aaron-bray This is where I encountered Kitware/kwiver#740